### PR TITLE
fix build fail on OS X

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -535,8 +535,8 @@ public class Keychain {
         return self.dynamicType.prettify(itemClass: itemClass, items: items())
     }
     
-    #if os(iOS)
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public func getSharedPassword(completion: (account: String?, password: String?, error: NSError?) -> () = { account, password, error -> () in }) {
         if let domain = server.host {
             self.dynamicType.requestSharedWebCredential(domain: domain, account: nil) { (credentials, error) -> () in
@@ -555,6 +555,7 @@ public class Keychain {
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public func getSharedPassword(account: String, completion: (password: String?, error: NSError?) -> () = { password, error -> () in }) {
         if let domain = server.host {
             self.dynamicType.requestSharedWebCredential(domain: domain, account: account) { (credentials, error) -> () in
@@ -575,6 +576,7 @@ public class Keychain {
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public func setSharedPassword(password: String, account: String, completion: (error: NSError?) -> () = { e -> () in }) {
         setSharedPassword(password as String?, account: account, completion: completion)
     }
@@ -595,21 +597,25 @@ public class Keychain {
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public func removeSharedPassword(account: String, completion: (error: NSError?) -> () = { e -> () in }) {
         setSharedPassword(nil, account: account, completion: completion)
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public class func requestSharedWebCredential(completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
         requestSharedWebCredential(domain: nil, account: nil, completion: completion)
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public class func requestSharedWebCredential(#domain: String, completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
         requestSharedWebCredential(domain: domain, account: nil, completion: completion)
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public class func requestSharedWebCredential(#domain: String, account: String, completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
         requestSharedWebCredential(domain: domain as String?, account: account as String?, completion: completion)
     }
@@ -632,9 +638,11 @@ public class Keychain {
                     if let account = credentials[kSecAttrAccount as! String] as? String {
                         credential["account"] = account
                     }
+                    #if os(iOS)
                     if let password = credentials[kSecSharedPassword.takeUnretainedValue() as! String] as? String {
                         credential["password"] = password
                     }
+                    #endif
                     return credential
                 }
                 completion(credentials: credentials, error: remoteError)
@@ -645,10 +653,10 @@ public class Keychain {
     }
     
     @availability(iOS, introduced=8.0)
+    @availability(OSX, unavailable)
     public class func generatePassword() -> String {
         return SecCreateSharedWebCredentialPassword().takeUnretainedValue() as! String
     }
-    #endif
     
     // MARK:
     
@@ -3994,3 +4002,15 @@ extension Status : RawRepresentable, Printable {
         }
     }
 }
+
+#if os(OSX)
+func SecCreateSharedWebCredentialPassword() -> Unmanaged<CFString>! {
+    fatalError("\(__FUNCTION__) does not exists")
+}
+func SecAddSharedWebCredential(fqdn: CFString!, account: CFString!, password: CFString!, completionHandler: ((CFError!) -> Void)!) {
+    fatalError("\(__FUNCTION__) does not exists")
+}
+func SecRequestSharedWebCredential(fqdn: CFString!, account: CFString!, completionHandler: ((CFArray!, CFError!) -> Void)!) {
+    fatalError("\(__FUNCTION__) does not exists")
+}
+#endif


### PR DESCRIPTION
It seems Xcode 6.3 does not exclude `#if os(iOS) #endif` block for building OS X.

Build error log is following:
```
CompileSwift normal x86_64 /Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift
    cd /Users/norio/Documents/workspace/github/KeychainAccess/Lib
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c -primary-file /Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk -I /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Products/Debug -F /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Products/Debug -application-extension -g -module-cache-path /Users/norio/Library/Developer/Xcode/DerivedData/ModuleCache -Xcc -I/Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/KeychainAccess-generated-files.hmap -Xcc -I/Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/KeychainAccess-own-target-headers.hmap -Xcc -I/Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/KeychainAccess-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/KeychainAccess-project-headers.hmap -Xcc -I/Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Products/Debug/include -Xcc -I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include -Xcc -I/Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/DerivedSources/x86_64 -Xcc -I/Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/DerivedSources -Xcc -DDEBUG=1 -Xcc -DDEBUG=1 -Xcc -working-directory/Users/norio/Documents/workspace/github/KeychainAccess/Lib -emit-module-doc-path /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/Objects-normal/x86_64/Keychain~partial.swiftdoc -Onone -parse-as-library -module-name KeychainAccess -emit-module-path /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/Objects-normal/x86_64/Keychain~partial.swiftmodule -serialize-diagnostics-path /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/Objects-normal/x86_64/Keychain.dia -emit-dependencies-path /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/Objects-normal/x86_64/Keychain.d -emit-reference-dependencies-path /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/Objects-normal/x86_64/Keychain.swiftdeps -o /Users/norio/Library/Developer/Xcode/DerivedData/KeychainAccess-aacvpjwepspanmddxsklcmyoedpu/Build/Intermediates/KeychainAccess.build/Debug/KeychainAccess-Mac.build/Objects-normal/x86_64/Keychain.o

/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:558:17: error: definition conflicts with previous value
    public func getSharedPassword(account: String, completion: (password: String?, error: NSError?) -> () = { password, error -> () in }) {
                ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:540:17: note: previous definition of 'getSharedPassword' is here
    public func getSharedPassword(completion: (account: String?, password: String?, error: NSError?) -> () = { account, password, error -> () in }) {
                ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:582:18: error: definition conflicts with previous value
    private func setSharedPassword(password: String?, account: String, completion: (error: NSError?) -> () = { e -> () in }) {
                 ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:578:17: note: previous definition of 'setSharedPassword' is here
    public func setSharedPassword(password: String, account: String, completion: (error: NSError?) -> () = { e -> () in }) {
                ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:608:23: error: definition conflicts with previous value
    public class func requestSharedWebCredential(#domain: String, completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
                      ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:603:23: note: previous definition of 'requestSharedWebCredential' is here
    public class func requestSharedWebCredential(completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
                      ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:613:23: error: definition conflicts with previous value
    public class func requestSharedWebCredential(#domain: String, account: String, completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
                      ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:603:23: note: previous definition of 'requestSharedWebCredential' is here
    public class func requestSharedWebCredential(completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
                      ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:617:24: error: definition conflicts with previous value
    private class func requestSharedWebCredential(#domain: String?, account: String?, completion: (credentials: [[String: String]], error: NSError?) -> ()) {
                       ^
/Users/norio/Documents/workspace/github/KeychainAccess/Lib/KeychainAccess/Keychain.swift:603:23: note: previous definition of 'requestSharedWebCredential' is here
    public class func requestSharedWebCredential(completion: (credentials: [[String: String]], error: NSError?) -> () = { credentials, error -> () in }) {
                      ^
```