### PR TITLE
Add overload subscripting methods

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -468,6 +468,34 @@ public class Keychain {
             }
         }
     }
+
+    public subscript(string key: String) -> String? {
+        get {
+            return get(key)
+        }
+
+        set {
+            if let value = newValue {
+                set(value, key: key)
+            } else {
+                remove(key)
+            }
+        }
+    }
+
+    public subscript(data key: String) -> NSData? {
+        get {
+            return getData(key)
+        }
+
+        set {
+            if let value = newValue {
+                set(value, key: key)
+            } else {
+                remove(key)
+            }
+        }
+    }
     
     // MARK:
     

--- a/Lib/KeychainAccessTests/KeychainAccessTests.swift
+++ b/Lib/KeychainAccessTests/KeychainAccessTests.swift
@@ -333,20 +333,36 @@ class KeychainAccessTests: XCTestCase {
         
         XCTAssertNil(keychain["username"], "not stored username")
         XCTAssertNil(keychain["password"], "not stored password")
+        XCTAssertNil(keychain[string: "username"], "not stored username")
+        XCTAssertNil(keychain[string: "password"], "not stored password")
         
         keychain["username"] = "kishikawakatsumi"
         XCTAssertEqual(keychain["username"]!, "kishikawakatsumi", "stored username")
+        XCTAssertEqual(keychain[string: "username"]!, "kishikawakatsumi", "stored username")
         
         keychain["password"] = "password1234"
         XCTAssertEqual(keychain["password"]!, "password1234", "stored password")
+        XCTAssertEqual(keychain[string: "password"]!, "password1234", "stored password")
         
         keychain["username"] = nil
         XCTAssertNil(keychain["username"], "removed username")
         XCTAssertEqual(keychain["password"]!, "password1234", "left password")
+        XCTAssertNil(keychain[string: "username"], "removed username")
+        XCTAssertEqual(keychain[string: "password"]!, "password1234", "left password")
         
         keychain["password"] = nil
         XCTAssertNil(keychain["username"], "removed username")
         XCTAssertNil(keychain["password"], "removed password")
+        XCTAssertNil(keychain[string: "username"], "removed username")
+        XCTAssertNil(keychain[string: "password"], "removed password")
+
+        let JSONObject = ["username": "kishikawakatsumi", "password": "password1234"]
+        let JSONData = NSJSONSerialization.dataWithJSONObject(JSONObject, options: nil, error: nil)
+
+        XCTAssertNil(keychain[data:"JSONData"], "not stored JSON data")
+
+        keychain[data: "JSONData"] = JSONData
+        XCTAssertEqual(keychain[data:"JSONData"]!, JSONData!, "stored JSON data")
     }
     
     // MARK:

--- a/README.md
+++ b/README.md
@@ -69,8 +69,20 @@ let keychain = Keychain(server: "https://github.com", protocolType: .HTTPS, auth
 
 #### subscripting
 
+##### for String
+
 ```swift
 keychain["kishikawakatsumi"] = "01234567-89ab-cdef-0123-456789abcdef"
+```
+
+```swift
+keychain[string: "kishikawakatsumi"] = "01234567-89ab-cdef-0123-456789abcdef"
+```
+
+##### for NSData
+
+```swift
+keychain[data: "secret"] = NSData(contentsOfFile: "secret.bin")
 ```
 
 #### set method
@@ -89,10 +101,22 @@ if let error = keychain.set("01234567-89ab-cdef-0123-456789abcdef", key: "kishik
 
 ### :key: Obtaining an item
 
-#### subscripting (automatically converts to string)
+#### subscripting
+
+##### for String (If the value is NSData, attempt to convert to String)
 
 ```swift
 let token = keychain["kishikawakatsumi"]
+```
+
+```swift
+let token = keychain[string: "kishikawakatsumi"]
+```
+
+##### for NSData
+
+```swift
+let secretData = keychain[data: "secret"]
 ```
 
 #### get methods


### PR DESCRIPTION
Now available set/get NSData to keychain by subscripting.

```swift
let secretData = keychain[data: "secret"]
keychain[data: "secret"] = NSData(contentsOfFile: "secret.bin")
```

