### PR TITLE
Fixed a spelling on Status Internal message.

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -2167,7 +2167,7 @@ extension Status : RawRepresentable, CustomStringConvertible {
         case Decode:
             return "Unable to decode the provided data."
         case Internal:
-            return "An internal error occured in the Security framework."
+            return "An internal error occurred in the Security framework."
         case UnsupportedAlgorithm:
             return "An unsupported algorithm was encountered."
         case UnsupportedOperation:


### PR DESCRIPTION
The work occurred was misspelt.