### PR TITLE
Fix casting an optional CFArray to Swift array in shared web credentials

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -870,8 +870,9 @@ public class Keychain {
                     print("error:[\(remoteError!.code)] \(remoteError!.localizedDescription)")
                 }
             }
-            if let credentials = credentials as? [[String: AnyObject]] {
-                let credentials = credentials.map { credentials -> [String: String] in
+            if let credentials = credentials {
+                let casted = credentials as NSArray
+                let credentials = casted.map { credentials -> [String: String] in
                     var credential = [String: String]()
                     if let server = credentials[AttributeServer] as? String {
                         credential["server"] = server


### PR DESCRIPTION
Fixes #197 

Swift fails to cast and optional CFArray into native Swift array, so instead of doing that we should first unwrap the optional CFArray and then cast to an NSArray, which can finally be casted (or mapped in this case) to a native Swift array.