### PR TITLE
Added Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ DerivedData
 # Bundler
 .bundle
 vendor/
+
+# Carthage
+Carthage/Build


### PR DESCRIPTION
When using the option `--use-submodules` with Carthage, the `Carthage/Build` directory shows in the submodule after `carthage build` making the submodule dirty.