### PR TITLE
Update for Swift 2.3

### DIFF
--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E61BF9EDCB004FFEC1 /* Debug.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -275,6 +276,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E71BF9EDCB004FFEC1 /* Release.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -1257,6 +1257,12 @@ extension ItemClass : RawRepresentable, CustomStringConvertible {
     }
 }
 
+extension SecAccessControlCreateFlags {
+    public init(rawValue: Int) {
+        self.rawValue = UInt(bitPattern: rawValue)
+    }
+}
+
 extension ProtocolType : RawRepresentable, CustomStringConvertible {
     
     public init?(rawValue: String) {

--- a/Lib/KeychainAccessTests/KeychainAccessTests.swift
+++ b/Lib/KeychainAccessTests/KeychainAccessTests.swift
@@ -550,12 +550,7 @@ class KeychainAccessTests: XCTestCase {
                 } else {
                     XCTAssertNotNil(attributes?.accessControl)
                 }
-                if #available(iOS 10.0, OSX 10.11, *) {
-                    XCTAssertEqual(attributes?.accessGroup, "com.apple.token")
-                }
-                else {
-                    XCTAssertEqual(attributes?.accessGroup, "")
-                }
+                XCTAssertEqual(attributes?.accessGroup, expectedAccessGroup)
                 XCTAssertNotNil(attributes?.synchronizable)
                 XCTAssertNotNil(attributes?.creationDate)
                 XCTAssertNotNil(attributes?.modificationDate)

--- a/Lib/KeychainAccessTests/KeychainAccessTests.swift
+++ b/Lib/KeychainAccessTests/KeychainAccessTests.swift
@@ -28,9 +28,18 @@ class KeychainAccessTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
     }
-    
+
+    var expectedAccessGroup: String {
+        if #available(iOS 10.0, OSX 10.11, *) {
+            return "com.apple.token"
+        }
+        else {
+            return ""
+        }
+    }
+
     // MARK:
-    
+
     func testGenericPassword() {
         do {
             // Add Keychain items
@@ -475,7 +484,7 @@ class KeychainAccessTests: XCTestCase {
                 XCTAssertNotNil(attributes?.persistentRef)
                 XCTAssertEqual(attributes?.accessible, Accessibility.WhenPasscodeSetThisDeviceOnly.rawValue)
                 XCTAssertNotNil(attributes?.accessControl)
-                XCTAssertEqual(attributes?.accessGroup, "")
+                XCTAssertEqual(attributes?.accessGroup, expectedAccessGroup)
                 XCTAssertNotNil(attributes?.synchronizable)
                 XCTAssertNotNil(attributes?.creationDate)
                 XCTAssertNotNil(attributes?.modificationDate)
@@ -541,7 +550,12 @@ class KeychainAccessTests: XCTestCase {
                 } else {
                     XCTAssertNotNil(attributes?.accessControl)
                 }
-                XCTAssertEqual(attributes?.accessGroup, "")
+                if #available(iOS 10.0, OSX 10.11, *) {
+                    XCTAssertEqual(attributes?.accessGroup, "com.apple.token")
+                }
+                else {
+                    XCTAssertEqual(attributes?.accessGroup, "")
+                }
                 XCTAssertNotNil(attributes?.synchronizable)
                 XCTAssertNotNil(attributes?.creationDate)
                 XCTAssertNotNil(attributes?.modificationDate)
@@ -583,7 +597,7 @@ class KeychainAccessTests: XCTestCase {
                 } else {
                     XCTAssertNotNil(attributes?.accessControl)
                 }
-                XCTAssertEqual(attributes?.accessGroup, "")
+                XCTAssertEqual(attributes?.accessGroup, expectedAccessGroup)
                 XCTAssertNotNil(attributes?.synchronizable)
                 XCTAssertNotNil(attributes?.creationDate)
                 XCTAssertNotNil(attributes?.modificationDate)
@@ -626,7 +640,7 @@ class KeychainAccessTests: XCTestCase {
                 } else {
                     XCTAssertNotNil(attributes?.accessControl)
                 }
-                XCTAssertEqual(attributes?.accessGroup, "")
+                XCTAssertEqual(attributes?.accessGroup, expectedAccessGroup)
                 XCTAssertNotNil(attributes?.synchronizable)
                 XCTAssertNotNil(attributes?.creationDate)
                 XCTAssertNotNil(attributes?.modificationDate)
@@ -1017,7 +1031,7 @@ class KeychainAccessTests: XCTestCase {
                 return value1.compare(value2) == NSComparisonResult.OrderedAscending || value1.compare(value2) == NSComparisonResult.OrderedSame
             }
 
-            XCTAssertEqual(sortedItems[0]["accessGroup"] as? String, "")
+            XCTAssertEqual(sortedItems[0]["accessGroup"] as? String, expectedAccessGroup)
             XCTAssertEqual(sortedItems[0]["synchronizable"] as? String, "false")
             XCTAssertEqual(sortedItems[0]["service"] as? String, "")
             XCTAssertEqual(sortedItems[0]["value"] as? String, "value1")
@@ -1025,7 +1039,7 @@ class KeychainAccessTests: XCTestCase {
             XCTAssertEqual(sortedItems[0]["class"] as? String, "GenericPassword")
             XCTAssertEqual(sortedItems[0]["accessibility"] as? String, "AfterFirstUnlock")
 
-            XCTAssertEqual(sortedItems[1]["accessGroup"] as? String, "")
+            XCTAssertEqual(sortedItems[1]["accessGroup"] as? String, expectedAccessGroup)
             XCTAssertEqual(sortedItems[1]["synchronizable"] as? String, "false")
             XCTAssertEqual(sortedItems[1]["service"] as? String, "")
             XCTAssertEqual(sortedItems[1]["value"] as? String, "value2")
@@ -1033,7 +1047,7 @@ class KeychainAccessTests: XCTestCase {
             XCTAssertEqual(sortedItems[1]["class"] as? String, "GenericPassword")
             XCTAssertEqual(sortedItems[1]["accessibility"] as? String, "AfterFirstUnlock")
 
-            XCTAssertEqual(sortedItems[2]["accessGroup"] as? String, "")
+            XCTAssertEqual(sortedItems[2]["accessGroup"] as? String, expectedAccessGroup)
             XCTAssertEqual(sortedItems[2]["synchronizable"] as? String, "false")
             XCTAssertEqual(sortedItems[2]["service"] as? String, "")
             XCTAssertEqual(sortedItems[2]["value"] as? String, "value3")
@@ -1066,7 +1080,7 @@ class KeychainAccessTests: XCTestCase {
                 return value1.compare(value2) == NSComparisonResult.OrderedAscending || value1.compare(value2) == NSComparisonResult.OrderedSame
             }
 
-            XCTAssertEqual(sortedItems[0]["accessGroup"] as? String, "")
+            XCTAssertEqual(sortedItems[0]["accessGroup"] as? String, expectedAccessGroup)
             XCTAssertEqual(sortedItems[0]["synchronizable"] as? String, "true")
             XCTAssertEqual(sortedItems[0]["service"] as? String, "service1")
             XCTAssertEqual(sortedItems[0]["value"] as? String, "service1_value1")
@@ -1074,7 +1088,7 @@ class KeychainAccessTests: XCTestCase {
             XCTAssertEqual(sortedItems[0]["class"] as? String, "GenericPassword")
             XCTAssertEqual(sortedItems[0]["accessibility"] as? String, "WhenUnlockedThisDeviceOnly")
 
-            XCTAssertEqual(sortedItems[1]["accessGroup"] as? String, "")
+            XCTAssertEqual(sortedItems[1]["accessGroup"] as? String, expectedAccessGroup)
             XCTAssertEqual(sortedItems[1]["synchronizable"] as? String, "false")
             XCTAssertEqual(sortedItems[1]["service"] as? String, "service1")
             XCTAssertEqual(sortedItems[1]["value"] as? String, "service1_value2")


### PR DESCRIPTION
This updates the project for Swift 2.3. This PR does 3 things

1. Enables 'Legacy' Swift
2. Adds a new constructor to `SecAccessControlCreateFlags` to specify an Int to adapt to the Int -> UInt rawValue change in iOS 10.0
3. Updates the test with a change in access group behavior.

Not sure how to manage legacy swift support with 3.0 support. I'm also assuming the change in access group behavior is due to test runner changes in iOS 10.0, and not due to me doing something incorrectly.

Brian