### PR TITLE
Add support for Swift 2.3 & Xcode 8 while maintaining Swift 2.2 & Xcode 7 support still

### DIFF
--- a/Examples/Example-iOS/Example-iOS.xcodeproj/xcshareddata/xcschemes/Example-iOS.xcscheme
+++ b/Examples/Example-iOS/Example-iOS.xcodeproj/xcshareddata/xcschemes/Example-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "kishikawa katsumi";
 				TargetAttributes = {
 					140F195B1A49D79400B0016A = {
@@ -268,6 +268,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E61BF9EDCB004FFEC1 /* Debug.xcconfig */;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -277,6 +278,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E71BF9EDCB004FFEC1 /* Release.xcconfig */;
 			buildSettings = {
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -1257,6 +1257,17 @@ extension ItemClass : RawRepresentable, CustomStringConvertible {
     }
 }
 
+#if swift(>=2.3)
+    
+@available(OSX 10.10, *)
+extension SecAccessControlCreateFlags {
+    public init(rawValue: Int) {
+        self.rawValue = UInt(bitPattern: rawValue)
+    }
+}
+    
+#endif
+
 extension ProtocolType : RawRepresentable, CustomStringConvertible {
     
     public init?(rawValue: String) {


### PR DESCRIPTION
I noticed that there are a couple of PRs for Swift 2.3 and 3.0 support however both of them fail on Travis so they're not suitable to be merged back into master, especially as we're only on beta 1 of Xcode 8 :).

However, this PR is slightly different, It's an update to the existing Swift 2.2 codebase that includes conditional support for the Swift 2.3 compiler meaning that it will compile using Xcode 7 and Swift 2.2 as it was but also fixes compile issues that prevented it's use from Swift 2.3.

All tests are passing and I don't see why there is any reason for it not to be merged back into master.

Exact changes:
* Update project to recommended build settings in Xcode 7.
* Enabled Legacy swift in Xcode 8 (Set the `SWIFT_VERSION` build setting to `2.3`, has no impact in Xcode 7).
* Adds a new constructor to SecAccessControlCreateFlags to specify an Int to adapt to the Int -> UInt rawValue change in Swift 2.3 - Adapted from #218, Also fixes #217 

