### PR TITLE
Split into OS X and iOS build targets

### DIFF
--- a/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
@@ -13,32 +13,11 @@
 		14DAEEA01A51E1BE0070B77E /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 14DAEE9E1A51E1BE0070B77E /* LaunchScreen.xib */; };
 		14DAEEB71A51E2690070B77E /* AccountsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DAEEB51A51E2690070B77E /* AccountsViewController.swift */; };
 		14DAEEB81A51E2690070B77E /* InputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DAEEB61A51E2690070B77E /* InputViewController.swift */; };
-		14DAEEC91A51E2D00070B77E /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */; };
-		14DAEECB1A51E2E10070B77E /* KeychainAccess.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5506E4A91D187016000F03AF /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5506E4A01D186FC7000F03AF /* KeychainAccess.framework */; };
+		5506E4AA1D187016000F03AF /* KeychainAccess.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5506E4A01D186FC7000F03AF /* KeychainAccess.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		14B1A52C1BE5395100005DBB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 14FDD4601B49B9AD00C39FE8;
-			remoteInfo = "KeychainAccess-watchOS";
-		};
-		14B1A52E1BE5395100005DBB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 145EEB8F1BCBEBC0001341DE;
-			remoteInfo = "KeychainAccess-tvOS";
-		};
-		14B1A5301BE5395100005DBB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 145EEB981BCBEBC0001341DE;
-			remoteInfo = "KeychainAccess-tvOSTests";
-		};
 		14DAEEC01A51E2A60070B77E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
@@ -53,31 +32,39 @@
 			remoteGlobalIDString = 140F19671A49D79500B0016A;
 			remoteInfo = "KeychainAccess-iOSTests";
 		};
-		14DAEEC41A51E2A60070B77E /* PBXContainerItemProxy */ = {
+		5506E49F1D186FC7000F03AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 140C8F0A1A4EBE3100F85556;
-			remoteInfo = "KeychainAccess-Mac";
+			remoteGlobalIDString = 5506E4891D186DA6000F03AF;
+			remoteInfo = "KeychainAccess iOS";
 		};
-		14DAEEC61A51E2A60070B77E /* PBXContainerItemProxy */ = {
+		5506E4A11D186FC7000F03AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 140C8F141A4EBE3100F85556;
-			remoteInfo = "KeychainAccess-MacTests";
+			remoteGlobalIDString = 5506E4981D186E12000F03AF;
+			remoteInfo = "KeychainAccessTests iOS";
+		};
+		5506E4AB1D187016000F03AF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 5506E47F1D186DA6000F03AF;
+			remoteInfo = "KeychainAccess iOS";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		14DAEECA1A51E2D70070B77E /* CopyFiles */ = {
+		5506E4AD1D187017000F03AF /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				14DAEECB1A51E2E10070B77E /* KeychainAccess.framework in CopyFiles */,
+				5506E4AA1D187016000F03AF /* KeychainAccess.framework in Embed Frameworks */,
 			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -99,7 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				14DAEEC91A51E2D00070B77E /* KeychainAccess.framework in Frameworks */,
+				5506E4A91D187016000F03AF /* KeychainAccess.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,12 +136,9 @@
 			isa = PBXGroup;
 			children = (
 				14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */,
-				14DAEEC31A51E2A60070B77E /* KeychainAccess-iOSTests.xctest */,
-				14DAEEC51A51E2A60070B77E /* KeychainAccess.framework */,
-				14DAEEC71A51E2A60070B77E /* KeychainAccess-MacTests.xctest */,
-				14B1A52D1BE5395100005DBB /* KeychainAccess.framework */,
-				14B1A52F1BE5395100005DBB /* KeychainAccess.framework */,
-				14B1A5311BE5395100005DBB /* KeychainAccess-tvOSTests.xctest */,
+				14DAEEC31A51E2A60070B77E /* KeychainAccessTests OSX.xctest */,
+				5506E4A01D186FC7000F03AF /* KeychainAccess.framework */,
+				5506E4A21D186FC7000F03AF /* KeychainAccessTests iOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -169,11 +153,12 @@
 				14DAEE8C1A51E1BE0070B77E /* Sources */,
 				14DAEE8D1A51E1BE0070B77E /* Frameworks */,
 				14DAEE8E1A51E1BE0070B77E /* Resources */,
-				14DAEECA1A51E2D70070B77E /* CopyFiles */,
+				5506E4AD1D187017000F03AF /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				5506E4AC1D187016000F03AF /* PBXTargetDependency */,
 			);
 			name = "Example-iOS";
 			productName = "Example-iOS";
@@ -220,27 +205,6 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		14B1A52D1BE5395100005DBB /* KeychainAccess.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = KeychainAccess.framework;
-			remoteRef = 14B1A52C1BE5395100005DBB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		14B1A52F1BE5395100005DBB /* KeychainAccess.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = KeychainAccess.framework;
-			remoteRef = 14B1A52E1BE5395100005DBB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		14B1A5311BE5395100005DBB /* KeychainAccess-tvOSTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "KeychainAccess-tvOSTests.xctest";
-			remoteRef = 14B1A5301BE5395100005DBB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -248,25 +212,25 @@
 			remoteRef = 14DAEEC01A51E2A60070B77E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		14DAEEC31A51E2A60070B77E /* KeychainAccess-iOSTests.xctest */ = {
+		14DAEEC31A51E2A60070B77E /* KeychainAccessTests OSX.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "KeychainAccess-iOSTests.xctest";
+			path = "KeychainAccessTests OSX.xctest";
 			remoteRef = 14DAEEC21A51E2A60070B77E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		14DAEEC51A51E2A60070B77E /* KeychainAccess.framework */ = {
+		5506E4A01D186FC7000F03AF /* KeychainAccess.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = KeychainAccess.framework;
-			remoteRef = 14DAEEC41A51E2A60070B77E /* PBXContainerItemProxy */;
+			remoteRef = 5506E49F1D186FC7000F03AF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		14DAEEC71A51E2A60070B77E /* KeychainAccess-MacTests.xctest */ = {
+		5506E4A21D186FC7000F03AF /* KeychainAccessTests iOS.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "KeychainAccess-MacTests.xctest";
-			remoteRef = 14DAEEC61A51E2A60070B77E /* PBXContainerItemProxy */;
+			path = "KeychainAccessTests iOS.xctest";
+			remoteRef = 5506E4A11D186FC7000F03AF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -296,6 +260,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5506E4AC1D187016000F03AF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "KeychainAccess iOS";
+			targetProxy = 5506E4AB1D187016000F03AF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		14DAEE991A51E1BE0070B77E /* Main.storyboard */ = {
@@ -399,6 +371,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Example-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
@@ -410,6 +383,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Example-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -13,10 +13,23 @@
 		142EDA851BCB505F00A32149 /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
 		142EDB041BCBB0DD00A32149 /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 		148F9D4A1BCB4118006EDF48 /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
+		5506E4811D186DA6000F03AF /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F197A1A49D89200B0016A /* Keychain.swift */; };
+		5506E4841D186DA6000F03AF /* KeychainAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 140F19611A49D79400B0016A /* KeychainAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5506E48F1D186E12000F03AF /* KeychainAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F196E1A49D79500B0016A /* KeychainAccessTests.swift */; };
+		5506E4901D186E12000F03AF /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
+		5506E4911D186E12000F03AF /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
+		5506E4921D186E12000F03AF /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		140F19691A49D79500B0016A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 140F19531A49D79400B0016A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 140F195B1A49D79400B0016A;
+			remoteInfo = KeychainAccess;
+		};
+		5506E48D1D186E12000F03AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 140F19531A49D79400B0016A /* Project object */;
 			proxyType = 1;
@@ -29,7 +42,7 @@
 		140F195C1A49D79400B0016A /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		140F19601A49D79400B0016A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		140F19611A49D79400B0016A /* KeychainAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeychainAccess.h; sourceTree = "<group>"; };
-		140F19671A49D79500B0016A /* KeychainAccessTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeychainAccessTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		140F196D1A49D79500B0016A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		140F196E1A49D79500B0016A /* KeychainAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessTests.swift; sourceTree = "<group>"; };
 		140F197A1A49D89200B0016A /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
@@ -41,6 +54,8 @@
 		148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Tests.xcconfig; path = Configurations/Tests.xcconfig; sourceTree = "<group>"; };
 		148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = KeychainAccess.xcconfig; path = Configurations/KeychainAccess.xcconfig; sourceTree = "<group>"; };
 		148F9D491BCB4118006EDF48 /* EnumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTests.swift; sourceTree = "<group>"; };
+		5506E4891D186DA6000F03AF /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +67,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		140F19641A49D79500B0016A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4821D186DA6000F03AF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4931D186E12000F03AF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -75,7 +104,9 @@
 			isa = PBXGroup;
 			children = (
 				140F195C1A49D79400B0016A /* KeychainAccess.framework */,
-				140F19671A49D79500B0016A /* KeychainAccessTests.xctest */,
+				140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */,
+				5506E4891D186DA6000F03AF /* KeychainAccess.framework */,
+				5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -141,12 +172,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5506E4831D186DA6000F03AF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5506E4841D186DA6000F03AF /* KeychainAccess.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		140F195B1A49D79400B0016A /* KeychainAccess */ = {
+		140F195B1A49D79400B0016A /* KeychainAccess OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess" */;
+			buildConfigurationList = 140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess OSX" */;
 			buildPhases = (
 				140F19571A49D79400B0016A /* Sources */,
 				140F19581A49D79400B0016A /* Frameworks */,
@@ -157,14 +196,14 @@
 			);
 			dependencies = (
 			);
-			name = KeychainAccess;
+			name = "KeychainAccess OSX";
 			productName = KeychainAccess;
 			productReference = 140F195C1A49D79400B0016A /* KeychainAccess.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		140F19661A49D79500B0016A /* KeychainAccessTests */ = {
+		140F19661A49D79500B0016A /* KeychainAccessTests OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests" */;
+			buildConfigurationList = 140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests OSX" */;
 			buildPhases = (
 				140F19631A49D79500B0016A /* Sources */,
 				140F19641A49D79500B0016A /* Frameworks */,
@@ -175,9 +214,45 @@
 			dependencies = (
 				140F196A1A49D79500B0016A /* PBXTargetDependency */,
 			);
-			name = KeychainAccessTests;
+			name = "KeychainAccessTests OSX";
 			productName = KeychainAccessTests;
-			productReference = 140F19671A49D79500B0016A /* KeychainAccessTests.xctest */;
+			productReference = 140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		5506E47F1D186DA6000F03AF /* KeychainAccess iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5506E4861D186DA6000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccess iOS" */;
+			buildPhases = (
+				5506E4801D186DA6000F03AF /* Sources */,
+				5506E4821D186DA6000F03AF /* Frameworks */,
+				5506E4831D186DA6000F03AF /* Headers */,
+				5506E4851D186DA6000F03AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "KeychainAccess iOS";
+			productName = KeychainAccess;
+			productReference = 5506E4891D186DA6000F03AF /* KeychainAccess.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5506E48B1D186E12000F03AF /* KeychainAccessTests iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5506E4951D186E12000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccessTests iOS" */;
+			buildPhases = (
+				5506E48E1D186E12000F03AF /* Sources */,
+				5506E4931D186E12000F03AF /* Frameworks */,
+				5506E4941D186E12000F03AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5506E48C1D186E12000F03AF /* PBXTargetDependency */,
+			);
+			name = "KeychainAccessTests iOS";
+			productName = KeychainAccessTests;
+			productReference = 5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -210,8 +285,10 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				140F195B1A49D79400B0016A /* KeychainAccess */,
-				140F19661A49D79500B0016A /* KeychainAccessTests */,
+				140F195B1A49D79400B0016A /* KeychainAccess OSX */,
+				140F19661A49D79500B0016A /* KeychainAccessTests OSX */,
+				5506E47F1D186DA6000F03AF /* KeychainAccess iOS */,
+				5506E48B1D186E12000F03AF /* KeychainAccessTests iOS */,
 			);
 		};
 /* End PBXProject section */
@@ -225,6 +302,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		140F19651A49D79500B0016A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4851D186DA6000F03AF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4941D186E12000F03AF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -253,13 +344,37 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5506E4801D186DA6000F03AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5506E4811D186DA6000F03AF /* Keychain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E48E1D186E12000F03AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5506E48F1D186E12000F03AF /* KeychainAccessTests.swift in Sources */,
+				5506E4901D186E12000F03AF /* EnumTests.swift in Sources */,
+				5506E4911D186E12000F03AF /* ErrorTypeTests.swift in Sources */,
+				5506E4921D186E12000F03AF /* SharedCredentialTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		140F196A1A49D79500B0016A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 140F195B1A49D79400B0016A /* KeychainAccess */;
+			target = 140F195B1A49D79400B0016A /* KeychainAccess OSX */;
 			targetProxy = 140F19691A49D79500B0016A /* PBXContainerItemProxy */;
+		};
+		5506E48C1D186E12000F03AF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 140F195B1A49D79400B0016A /* KeychainAccess OSX */;
+			targetProxy = 5506E48D1D186E12000F03AF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -268,6 +383,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E61BF9EDCB004FFEC1 /* Debug.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -275,6 +391,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E71BF9EDCB004FFEC1 /* Release.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -282,6 +399,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 			};
 			name = Debug;
 		};
@@ -289,6 +408,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 			};
 			name = Release;
 		};
@@ -296,6 +417,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -303,6 +425,51 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		5506E4871D186DA6000F03AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+		5506E4881D186DA6000F03AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Release;
+		};
+		5506E4961D186E12000F03AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+		5506E4971D186E12000F03AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
 		};
@@ -318,7 +485,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess" */ = {
+		140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				140F19731A49D79500B0016A /* Debug */,
@@ -327,11 +494,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests" */ = {
+		140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				140F19761A49D79500B0016A /* Debug */,
 				140F19771A49D79500B0016A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5506E4861D186DA6000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccess iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5506E4871D186DA6000F03AF /* Debug */,
+				5506E4881D186DA6000F03AF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5506E4951D186E12000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccessTests iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5506E4961D186E12000F03AF /* Debug */,
+				5506E4971D186E12000F03AF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess OSX.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess OSX.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "140F195B1A49D79400B0016A"
                BuildableName = "KeychainAccess.framework"
-               BlueprintName = "KeychainAccess"
+               BlueprintName = "KeychainAccess OSX"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,8 +29,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "140F19661A49D79500B0016A"
-               BuildableName = "KeychainAccessTests.xctest"
-               BlueprintName = "KeychainAccessTests"
+               BuildableName = "KeychainAccessTests OSX.xctest"
+               BlueprintName = "KeychainAccessTests OSX"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +47,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "140F19661A49D79500B0016A"
-               BuildableName = "KeychainAccessTests.xctest"
-               BlueprintName = "KeychainAccessTests"
+               BuildableName = "KeychainAccessTests OSX.xctest"
+               BlueprintName = "KeychainAccessTests OSX"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +58,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "140F195B1A49D79400B0016A"
             BuildableName = "KeychainAccess.framework"
-            BlueprintName = "KeychainAccess"
+            BlueprintName = "KeychainAccess OSX"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +80,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "140F195B1A49D79400B0016A"
             BuildableName = "KeychainAccess.framework"
-            BlueprintName = "KeychainAccess"
+            BlueprintName = "KeychainAccess OSX"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +98,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "140F195B1A49D79400B0016A"
             BuildableName = "KeychainAccess.framework"
-            BlueprintName = "KeychainAccess"
+            BlueprintName = "KeychainAccess OSX"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess iOS.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess iOS.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+               BuildableName = "KeychainAccess.framework"
+               BlueprintName = "KeychainAccess iOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5506E48B1D186E12000F03AF"
+               BuildableName = "KeychainAccessTests iOS.xctest"
+               BlueprintName = "KeychainAccessTests iOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5506E48B1D186E12000F03AF"
+               BuildableName = "KeychainAccessTests iOS.xctest"
+               BlueprintName = "KeychainAccessTests iOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+            BuildableName = "KeychainAccess.framework"
+            BlueprintName = "KeychainAccess iOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+            BuildableName = "KeychainAccess.framework"
+            BlueprintName = "KeychainAccess iOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+            BuildableName = "KeychainAccess.framework"
+            BlueprintName = "KeychainAccess iOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Fixes #208 

I'm not much of an expert on build targets, but this worked for me. I didn't create tvOS or watchOS targets, though - targets for those can be created similarly.

The example iOS app was updated to grab the new build target, too.