### PR TITLE
Split targets into OS X, iOS, tvOS, watchOS

### DIFF
--- a/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
@@ -13,32 +13,11 @@
 		14DAEEA01A51E1BE0070B77E /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 14DAEE9E1A51E1BE0070B77E /* LaunchScreen.xib */; };
 		14DAEEB71A51E2690070B77E /* AccountsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DAEEB51A51E2690070B77E /* AccountsViewController.swift */; };
 		14DAEEB81A51E2690070B77E /* InputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DAEEB61A51E2690070B77E /* InputViewController.swift */; };
-		14DAEEC91A51E2D00070B77E /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */; };
-		14DAEECB1A51E2E10070B77E /* KeychainAccess.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5506E4A91D187016000F03AF /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5506E4A01D186FC7000F03AF /* KeychainAccess.framework */; };
+		5506E4AA1D187016000F03AF /* KeychainAccess.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5506E4A01D186FC7000F03AF /* KeychainAccess.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		14B1A52C1BE5395100005DBB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 14FDD4601B49B9AD00C39FE8;
-			remoteInfo = "KeychainAccess-watchOS";
-		};
-		14B1A52E1BE5395100005DBB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 145EEB8F1BCBEBC0001341DE;
-			remoteInfo = "KeychainAccess-tvOS";
-		};
-		14B1A5301BE5395100005DBB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 145EEB981BCBEBC0001341DE;
-			remoteInfo = "KeychainAccess-tvOSTests";
-		};
 		14DAEEC01A51E2A60070B77E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
@@ -53,31 +32,39 @@
 			remoteGlobalIDString = 140F19671A49D79500B0016A;
 			remoteInfo = "KeychainAccess-iOSTests";
 		};
-		14DAEEC41A51E2A60070B77E /* PBXContainerItemProxy */ = {
+		5506E49F1D186FC7000F03AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 140C8F0A1A4EBE3100F85556;
-			remoteInfo = "KeychainAccess-Mac";
+			remoteGlobalIDString = 5506E4891D186DA6000F03AF;
+			remoteInfo = "KeychainAccess iOS";
 		};
-		14DAEEC61A51E2A60070B77E /* PBXContainerItemProxy */ = {
+		5506E4A11D186FC7000F03AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 140C8F141A4EBE3100F85556;
-			remoteInfo = "KeychainAccess-MacTests";
+			remoteGlobalIDString = 5506E4981D186E12000F03AF;
+			remoteInfo = "KeychainAccessTests iOS";
+		};
+		5506E4AB1D187016000F03AF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 14DAEEB91A51E2A60070B77E /* KeychainAccess.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 5506E47F1D186DA6000F03AF;
+			remoteInfo = "KeychainAccess iOS";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		14DAEECA1A51E2D70070B77E /* CopyFiles */ = {
+		5506E4AD1D187017000F03AF /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				14DAEECB1A51E2E10070B77E /* KeychainAccess.framework in CopyFiles */,
+				5506E4AA1D187016000F03AF /* KeychainAccess.framework in Embed Frameworks */,
 			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -99,7 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				14DAEEC91A51E2D00070B77E /* KeychainAccess.framework in Frameworks */,
+				5506E4A91D187016000F03AF /* KeychainAccess.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,12 +136,9 @@
 			isa = PBXGroup;
 			children = (
 				14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */,
-				14DAEEC31A51E2A60070B77E /* KeychainAccess-iOSTests.xctest */,
-				14DAEEC51A51E2A60070B77E /* KeychainAccess.framework */,
-				14DAEEC71A51E2A60070B77E /* KeychainAccess-MacTests.xctest */,
-				14B1A52D1BE5395100005DBB /* KeychainAccess.framework */,
-				14B1A52F1BE5395100005DBB /* KeychainAccess.framework */,
-				14B1A5311BE5395100005DBB /* KeychainAccess-tvOSTests.xctest */,
+				14DAEEC31A51E2A60070B77E /* KeychainAccessTests OSX.xctest */,
+				5506E4A01D186FC7000F03AF /* KeychainAccess.framework */,
+				5506E4A21D186FC7000F03AF /* KeychainAccessTests iOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -169,11 +153,12 @@
 				14DAEE8C1A51E1BE0070B77E /* Sources */,
 				14DAEE8D1A51E1BE0070B77E /* Frameworks */,
 				14DAEE8E1A51E1BE0070B77E /* Resources */,
-				14DAEECA1A51E2D70070B77E /* CopyFiles */,
+				5506E4AD1D187017000F03AF /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				5506E4AC1D187016000F03AF /* PBXTargetDependency */,
 			);
 			name = "Example-iOS";
 			productName = "Example-iOS";
@@ -220,27 +205,6 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		14B1A52D1BE5395100005DBB /* KeychainAccess.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = KeychainAccess.framework;
-			remoteRef = 14B1A52C1BE5395100005DBB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		14B1A52F1BE5395100005DBB /* KeychainAccess.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = KeychainAccess.framework;
-			remoteRef = 14B1A52E1BE5395100005DBB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		14B1A5311BE5395100005DBB /* KeychainAccess-tvOSTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "KeychainAccess-tvOSTests.xctest";
-			remoteRef = 14B1A5301BE5395100005DBB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		14DAEEC11A51E2A60070B77E /* KeychainAccess.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -248,25 +212,25 @@
 			remoteRef = 14DAEEC01A51E2A60070B77E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		14DAEEC31A51E2A60070B77E /* KeychainAccess-iOSTests.xctest */ = {
+		14DAEEC31A51E2A60070B77E /* KeychainAccessTests OSX.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "KeychainAccess-iOSTests.xctest";
+			path = "KeychainAccessTests OSX.xctest";
 			remoteRef = 14DAEEC21A51E2A60070B77E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		14DAEEC51A51E2A60070B77E /* KeychainAccess.framework */ = {
+		5506E4A01D186FC7000F03AF /* KeychainAccess.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = KeychainAccess.framework;
-			remoteRef = 14DAEEC41A51E2A60070B77E /* PBXContainerItemProxy */;
+			remoteRef = 5506E49F1D186FC7000F03AF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		14DAEEC71A51E2A60070B77E /* KeychainAccess-MacTests.xctest */ = {
+		5506E4A21D186FC7000F03AF /* KeychainAccessTests iOS.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "KeychainAccess-MacTests.xctest";
-			remoteRef = 14DAEEC61A51E2A60070B77E /* PBXContainerItemProxy */;
+			path = "KeychainAccessTests iOS.xctest";
+			remoteRef = 5506E4A11D186FC7000F03AF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -296,6 +260,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5506E4AC1D187016000F03AF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "KeychainAccess iOS";
+			targetProxy = 5506E4AB1D187016000F03AF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		14DAEE991A51E1BE0070B77E /* Main.storyboard */ = {
@@ -399,6 +371,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Example-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";
@@ -410,6 +383,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Example-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kishikawakatsumi.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -13,10 +13,23 @@
 		142EDA851BCB505F00A32149 /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
 		142EDB041BCBB0DD00A32149 /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 		148F9D4A1BCB4118006EDF48 /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
+		5506E4811D186DA6000F03AF /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F197A1A49D89200B0016A /* Keychain.swift */; };
+		5506E4841D186DA6000F03AF /* KeychainAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 140F19611A49D79400B0016A /* KeychainAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5506E48F1D186E12000F03AF /* KeychainAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F196E1A49D79500B0016A /* KeychainAccessTests.swift */; };
+		5506E4901D186E12000F03AF /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
+		5506E4911D186E12000F03AF /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
+		5506E4921D186E12000F03AF /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		140F19691A49D79500B0016A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 140F19531A49D79400B0016A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 140F195B1A49D79400B0016A;
+			remoteInfo = KeychainAccess;
+		};
+		5506E48D1D186E12000F03AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 140F19531A49D79400B0016A /* Project object */;
 			proxyType = 1;
@@ -29,7 +42,7 @@
 		140F195C1A49D79400B0016A /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		140F19601A49D79400B0016A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		140F19611A49D79400B0016A /* KeychainAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeychainAccess.h; sourceTree = "<group>"; };
-		140F19671A49D79500B0016A /* KeychainAccessTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeychainAccessTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		140F196D1A49D79500B0016A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		140F196E1A49D79500B0016A /* KeychainAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessTests.swift; sourceTree = "<group>"; };
 		140F197A1A49D89200B0016A /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
@@ -41,6 +54,8 @@
 		148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Tests.xcconfig; path = Configurations/Tests.xcconfig; sourceTree = "<group>"; };
 		148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = KeychainAccess.xcconfig; path = Configurations/KeychainAccess.xcconfig; sourceTree = "<group>"; };
 		148F9D491BCB4118006EDF48 /* EnumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTests.swift; sourceTree = "<group>"; };
+		5506E4891D186DA6000F03AF /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +67,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		140F19641A49D79500B0016A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4821D186DA6000F03AF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4931D186E12000F03AF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -75,7 +104,9 @@
 			isa = PBXGroup;
 			children = (
 				140F195C1A49D79400B0016A /* KeychainAccess.framework */,
-				140F19671A49D79500B0016A /* KeychainAccessTests.xctest */,
+				140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */,
+				5506E4891D186DA6000F03AF /* KeychainAccess.framework */,
+				5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -141,12 +172,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5506E4831D186DA6000F03AF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5506E4841D186DA6000F03AF /* KeychainAccess.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		140F195B1A49D79400B0016A /* KeychainAccess */ = {
+		140F195B1A49D79400B0016A /* KeychainAccess OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess" */;
+			buildConfigurationList = 140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess OSX" */;
 			buildPhases = (
 				140F19571A49D79400B0016A /* Sources */,
 				140F19581A49D79400B0016A /* Frameworks */,
@@ -157,14 +196,14 @@
 			);
 			dependencies = (
 			);
-			name = KeychainAccess;
+			name = "KeychainAccess OSX";
 			productName = KeychainAccess;
 			productReference = 140F195C1A49D79400B0016A /* KeychainAccess.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		140F19661A49D79500B0016A /* KeychainAccessTests */ = {
+		140F19661A49D79500B0016A /* KeychainAccessTests OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests" */;
+			buildConfigurationList = 140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests OSX" */;
 			buildPhases = (
 				140F19631A49D79500B0016A /* Sources */,
 				140F19641A49D79500B0016A /* Frameworks */,
@@ -175,9 +214,45 @@
 			dependencies = (
 				140F196A1A49D79500B0016A /* PBXTargetDependency */,
 			);
-			name = KeychainAccessTests;
+			name = "KeychainAccessTests OSX";
 			productName = KeychainAccessTests;
-			productReference = 140F19671A49D79500B0016A /* KeychainAccessTests.xctest */;
+			productReference = 140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		5506E47F1D186DA6000F03AF /* KeychainAccess iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5506E4861D186DA6000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccess iOS" */;
+			buildPhases = (
+				5506E4801D186DA6000F03AF /* Sources */,
+				5506E4821D186DA6000F03AF /* Frameworks */,
+				5506E4831D186DA6000F03AF /* Headers */,
+				5506E4851D186DA6000F03AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "KeychainAccess iOS";
+			productName = KeychainAccess;
+			productReference = 5506E4891D186DA6000F03AF /* KeychainAccess.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5506E48B1D186E12000F03AF /* KeychainAccessTests iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5506E4951D186E12000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccessTests iOS" */;
+			buildPhases = (
+				5506E48E1D186E12000F03AF /* Sources */,
+				5506E4931D186E12000F03AF /* Frameworks */,
+				5506E4941D186E12000F03AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5506E48C1D186E12000F03AF /* PBXTargetDependency */,
+			);
+			name = "KeychainAccessTests iOS";
+			productName = KeychainAccessTests;
+			productReference = 5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -210,8 +285,10 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				140F195B1A49D79400B0016A /* KeychainAccess */,
-				140F19661A49D79500B0016A /* KeychainAccessTests */,
+				140F195B1A49D79400B0016A /* KeychainAccess OSX */,
+				140F19661A49D79500B0016A /* KeychainAccessTests OSX */,
+				5506E47F1D186DA6000F03AF /* KeychainAccess iOS */,
+				5506E48B1D186E12000F03AF /* KeychainAccessTests iOS */,
 			);
 		};
 /* End PBXProject section */
@@ -225,6 +302,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		140F19651A49D79500B0016A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4851D186DA6000F03AF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E4941D186E12000F03AF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -253,13 +344,37 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5506E4801D186DA6000F03AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5506E4811D186DA6000F03AF /* Keychain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5506E48E1D186E12000F03AF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5506E48F1D186E12000F03AF /* KeychainAccessTests.swift in Sources */,
+				5506E4901D186E12000F03AF /* EnumTests.swift in Sources */,
+				5506E4911D186E12000F03AF /* ErrorTypeTests.swift in Sources */,
+				5506E4921D186E12000F03AF /* SharedCredentialTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		140F196A1A49D79500B0016A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 140F195B1A49D79400B0016A /* KeychainAccess */;
+			target = 140F195B1A49D79400B0016A /* KeychainAccess OSX */;
 			targetProxy = 140F19691A49D79500B0016A /* PBXContainerItemProxy */;
+		};
+		5506E48C1D186E12000F03AF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 140F195B1A49D79400B0016A /* KeychainAccess OSX */;
+			targetProxy = 5506E48D1D186E12000F03AF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -268,6 +383,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E61BF9EDCB004FFEC1 /* Debug.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -275,6 +391,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E71BF9EDCB004FFEC1 /* Release.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -282,6 +399,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 			};
 			name = Debug;
 		};
@@ -289,6 +408,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 			};
 			name = Release;
 		};
@@ -296,6 +417,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -303,6 +425,51 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
 			buildSettings = {
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		5506E4871D186DA6000F03AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+		5506E4881D186DA6000F03AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Release;
+		};
+		5506E4961D186E12000F03AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+		5506E4971D186E12000F03AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
 		};
@@ -318,7 +485,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess" */ = {
+		140F19721A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccess OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				140F19731A49D79500B0016A /* Debug */,
@@ -327,11 +494,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests" */ = {
+		140F19751A49D79500B0016A /* Build configuration list for PBXNativeTarget "KeychainAccessTests OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				140F19761A49D79500B0016A /* Debug */,
 				140F19771A49D79500B0016A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5506E4861D186DA6000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccess iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5506E4871D186DA6000F03AF /* Debug */,
+				5506E4881D186DA6000F03AF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5506E4951D186E12000F03AF /* Build configuration list for PBXNativeTarget "KeychainAccessTests iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5506E4961D186E12000F03AF /* Debug */,
+				5506E4971D186E12000F03AF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -27,10 +27,6 @@
 		559642071D2451BA00CB6448 /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 		559642111D2451C100CB6448 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F197A1A49D89200B0016A /* Keychain.swift */; };
 		559642141D2451C100CB6448 /* KeychainAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 140F19611A49D79400B0016A /* KeychainAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5596421F1D2451C800CB6448 /* KeychainAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F196E1A49D79500B0016A /* KeychainAccessTests.swift */; };
-		559642201D2451C800CB6448 /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
-		559642211D2451C800CB6448 /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
-		559642221D2451C800CB6448 /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,13 +51,6 @@
 			remoteGlobalIDString = 559641F41D2451B200CB6448;
 			remoteInfo = "KeychainAccess tvOS";
 		};
-		5596422E1D2452E300CB6448 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 140F19531A49D79400B0016A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5596420F1D2451C100CB6448;
-			remoteInfo = "KeychainAccess watchOS";
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -85,7 +74,6 @@
 		559641FE1D2451B200CB6448 /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5596420D1D2451BA00CB6448 /* KeychainAccessTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		559642191D2451C100CB6448 /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		559642281D2451C800CB6448 /* KeychainAccessTests watchOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests watchOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,13 +126,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		559642231D2451C800CB6448 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -168,7 +149,6 @@
 				559641FE1D2451B200CB6448 /* KeychainAccess.framework */,
 				5596420D1D2451BA00CB6448 /* KeychainAccessTests tvOS.xctest */,
 				559642191D2451C100CB6448 /* KeychainAccess.framework */,
-				559642281D2451C800CB6448 /* KeychainAccessTests watchOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -387,24 +367,6 @@
 			productReference = 559642191D2451C100CB6448 /* KeychainAccess.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		5596421B1D2451C800CB6448 /* KeychainAccessTests watchOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 559642251D2451C800CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccessTests watchOS" */;
-			buildPhases = (
-				5596421E1D2451C800CB6448 /* Sources */,
-				559642231D2451C800CB6448 /* Frameworks */,
-				559642241D2451C800CB6448 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				5596422F1D2452E300CB6448 /* PBXTargetDependency */,
-			);
-			name = "KeychainAccessTests watchOS";
-			productName = KeychainAccessTests;
-			productReference = 559642281D2451C800CB6448 /* KeychainAccessTests watchOS.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -442,7 +404,6 @@
 				559641F41D2451B200CB6448 /* KeychainAccess tvOS */,
 				559642001D2451BA00CB6448 /* KeychainAccessTests tvOS */,
 				5596420F1D2451C100CB6448 /* KeychainAccess watchOS */,
-				5596421B1D2451C800CB6448 /* KeychainAccessTests watchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -491,13 +452,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		559642151D2451C100CB6448 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		559642241D2451C800CB6448 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -572,17 +526,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5596421E1D2451C800CB6448 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5596421F1D2451C800CB6448 /* KeychainAccessTests.swift in Sources */,
-				559642201D2451C800CB6448 /* EnumTests.swift in Sources */,
-				559642211D2451C800CB6448 /* ErrorTypeTests.swift in Sources */,
-				559642221D2451C800CB6448 /* SharedCredentialTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -600,11 +543,6 @@
 			isa = PBXTargetDependency;
 			target = 559641F41D2451B200CB6448 /* KeychainAccess tvOS */;
 			targetProxy = 5596422C1D2452DF00CB6448 /* PBXContainerItemProxy */;
-		};
-		5596422F1D2452E300CB6448 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 5596420F1D2451C100CB6448 /* KeychainAccess watchOS */;
-			targetProxy = 5596422E1D2452E300CB6448 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -769,28 +707,6 @@
 			};
 			name = Release;
 		};
-		559642261D2451C800CB6448 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = watchos;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos";
-			};
-			name = Debug;
-		};
-		559642271D2451C800CB6448 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
-			buildSettings = {
-				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = watchos;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -862,15 +778,6 @@
 			buildConfigurations = (
 				559642171D2451C100CB6448 /* Debug */,
 				559642181D2451C100CB6448 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		559642251D2451C800CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccessTests watchOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				559642261D2451C800CB6448 /* Debug */,
-				559642271D2451C800CB6448 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -19,6 +19,18 @@
 		5506E4901D186E12000F03AF /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
 		5506E4911D186E12000F03AF /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
 		5506E4921D186E12000F03AF /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
+		559641F61D2451B200CB6448 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F197A1A49D89200B0016A /* Keychain.swift */; };
+		559641F91D2451B200CB6448 /* KeychainAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 140F19611A49D79400B0016A /* KeychainAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		559642041D2451BA00CB6448 /* KeychainAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F196E1A49D79500B0016A /* KeychainAccessTests.swift */; };
+		559642051D2451BA00CB6448 /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
+		559642061D2451BA00CB6448 /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
+		559642071D2451BA00CB6448 /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
+		559642111D2451C100CB6448 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F197A1A49D89200B0016A /* Keychain.swift */; };
+		559642141D2451C100CB6448 /* KeychainAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 140F19611A49D79400B0016A /* KeychainAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5596421F1D2451C800CB6448 /* KeychainAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140F196E1A49D79500B0016A /* KeychainAccessTests.swift */; };
+		559642201D2451C800CB6448 /* EnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148F9D491BCB4118006EDF48 /* EnumTests.swift */; };
+		559642211D2451C800CB6448 /* ErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDA841BCB505F00A32149 /* ErrorTypeTests.swift */; };
+		559642221D2451C800CB6448 /* SharedCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142EDB031BCBB0DD00A32149 /* SharedCredentialTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -29,12 +41,26 @@
 			remoteGlobalIDString = 140F195B1A49D79400B0016A;
 			remoteInfo = KeychainAccess;
 		};
-		5506E48D1D186E12000F03AF /* PBXContainerItemProxy */ = {
+		5596422A1D2452D900CB6448 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 140F19531A49D79400B0016A /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 140F195B1A49D79400B0016A;
-			remoteInfo = KeychainAccess;
+			remoteGlobalIDString = 5506E47F1D186DA6000F03AF;
+			remoteInfo = "KeychainAccess iOS";
+		};
+		5596422C1D2452DF00CB6448 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 140F19531A49D79400B0016A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 559641F41D2451B200CB6448;
+			remoteInfo = "KeychainAccess tvOS";
+		};
+		5596422E1D2452E300CB6448 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 140F19531A49D79400B0016A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5596420F1D2451C100CB6448;
+			remoteInfo = "KeychainAccess watchOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -56,6 +82,10 @@
 		148F9D491BCB4118006EDF48 /* EnumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTests.swift; sourceTree = "<group>"; };
 		5506E4891D186DA6000F03AF /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		559641FE1D2451B200CB6448 /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5596420D1D2451BA00CB6448 /* KeychainAccessTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		559642191D2451C100CB6448 /* KeychainAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KeychainAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		559642281D2451C800CB6448 /* KeychainAccessTests watchOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KeychainAccessTests watchOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +117,34 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		559641F71D2451B200CB6448 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642081D2451BA00CB6448 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642121D2451C100CB6448 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642231D2451C800CB6448 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -107,6 +165,10 @@
 				140F19671A49D79500B0016A /* KeychainAccessTests OSX.xctest */,
 				5506E4891D186DA6000F03AF /* KeychainAccess.framework */,
 				5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */,
+				559641FE1D2451B200CB6448 /* KeychainAccess.framework */,
+				5596420D1D2451BA00CB6448 /* KeychainAccessTests tvOS.xctest */,
+				559642191D2451C100CB6448 /* KeychainAccess.framework */,
+				559642281D2451C800CB6448 /* KeychainAccessTests watchOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -180,6 +242,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		559641F81D2451B200CB6448 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				559641F91D2451B200CB6448 /* KeychainAccess.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642131D2451C100CB6448 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				559642141D2451C100CB6448 /* KeychainAccess.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -248,11 +326,83 @@
 			buildRules = (
 			);
 			dependencies = (
-				5506E48C1D186E12000F03AF /* PBXTargetDependency */,
+				5596422B1D2452D900CB6448 /* PBXTargetDependency */,
 			);
 			name = "KeychainAccessTests iOS";
 			productName = KeychainAccessTests;
 			productReference = 5506E4981D186E12000F03AF /* KeychainAccessTests iOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		559641F41D2451B200CB6448 /* KeychainAccess tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 559641FB1D2451B200CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccess tvOS" */;
+			buildPhases = (
+				559641F51D2451B200CB6448 /* Sources */,
+				559641F71D2451B200CB6448 /* Frameworks */,
+				559641F81D2451B200CB6448 /* Headers */,
+				559641FA1D2451B200CB6448 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "KeychainAccess tvOS";
+			productName = KeychainAccess;
+			productReference = 559641FE1D2451B200CB6448 /* KeychainAccess.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		559642001D2451BA00CB6448 /* KeychainAccessTests tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5596420A1D2451BA00CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccessTests tvOS" */;
+			buildPhases = (
+				559642031D2451BA00CB6448 /* Sources */,
+				559642081D2451BA00CB6448 /* Frameworks */,
+				559642091D2451BA00CB6448 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5596422D1D2452DF00CB6448 /* PBXTargetDependency */,
+			);
+			name = "KeychainAccessTests tvOS";
+			productName = KeychainAccessTests;
+			productReference = 5596420D1D2451BA00CB6448 /* KeychainAccessTests tvOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		5596420F1D2451C100CB6448 /* KeychainAccess watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 559642161D2451C100CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccess watchOS" */;
+			buildPhases = (
+				559642101D2451C100CB6448 /* Sources */,
+				559642121D2451C100CB6448 /* Frameworks */,
+				559642131D2451C100CB6448 /* Headers */,
+				559642151D2451C100CB6448 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "KeychainAccess watchOS";
+			productName = KeychainAccess;
+			productReference = 559642191D2451C100CB6448 /* KeychainAccess.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5596421B1D2451C800CB6448 /* KeychainAccessTests watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 559642251D2451C800CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccessTests watchOS" */;
+			buildPhases = (
+				5596421E1D2451C800CB6448 /* Sources */,
+				559642231D2451C800CB6448 /* Frameworks */,
+				559642241D2451C800CB6448 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5596422F1D2452E300CB6448 /* PBXTargetDependency */,
+			);
+			name = "KeychainAccessTests watchOS";
+			productName = KeychainAccessTests;
+			productReference = 559642281D2451C800CB6448 /* KeychainAccessTests watchOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -289,6 +439,10 @@
 				140F19661A49D79500B0016A /* KeychainAccessTests OSX */,
 				5506E47F1D186DA6000F03AF /* KeychainAccess iOS */,
 				5506E48B1D186E12000F03AF /* KeychainAccessTests iOS */,
+				559641F41D2451B200CB6448 /* KeychainAccess tvOS */,
+				559642001D2451BA00CB6448 /* KeychainAccessTests tvOS */,
+				5596420F1D2451C100CB6448 /* KeychainAccess watchOS */,
+				5596421B1D2451C800CB6448 /* KeychainAccessTests watchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -316,6 +470,34 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		5506E4941D186E12000F03AF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559641FA1D2451B200CB6448 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642091D2451BA00CB6448 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642151D2451C100CB6448 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642241D2451C800CB6448 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -363,6 +545,44 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		559641F51D2451B200CB6448 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				559641F61D2451B200CB6448 /* Keychain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642031D2451BA00CB6448 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				559642041D2451BA00CB6448 /* KeychainAccessTests.swift in Sources */,
+				559642051D2451BA00CB6448 /* EnumTests.swift in Sources */,
+				559642061D2451BA00CB6448 /* ErrorTypeTests.swift in Sources */,
+				559642071D2451BA00CB6448 /* SharedCredentialTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		559642101D2451C100CB6448 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				559642111D2451C100CB6448 /* Keychain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5596421E1D2451C800CB6448 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5596421F1D2451C800CB6448 /* KeychainAccessTests.swift in Sources */,
+				559642201D2451C800CB6448 /* EnumTests.swift in Sources */,
+				559642211D2451C800CB6448 /* ErrorTypeTests.swift in Sources */,
+				559642221D2451C800CB6448 /* SharedCredentialTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -371,10 +591,20 @@
 			target = 140F195B1A49D79400B0016A /* KeychainAccess OSX */;
 			targetProxy = 140F19691A49D79500B0016A /* PBXContainerItemProxy */;
 		};
-		5506E48C1D186E12000F03AF /* PBXTargetDependency */ = {
+		5596422B1D2452D900CB6448 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 140F195B1A49D79400B0016A /* KeychainAccess OSX */;
-			targetProxy = 5506E48D1D186E12000F03AF /* PBXContainerItemProxy */;
+			target = 5506E47F1D186DA6000F03AF /* KeychainAccess iOS */;
+			targetProxy = 5596422A1D2452D900CB6448 /* PBXContainerItemProxy */;
+		};
+		5596422D1D2452DF00CB6448 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 559641F41D2451B200CB6448 /* KeychainAccess tvOS */;
+			targetProxy = 5596422C1D2452DF00CB6448 /* PBXContainerItemProxy */;
+		};
+		5596422F1D2452E300CB6448 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5596420F1D2451C100CB6448 /* KeychainAccess watchOS */;
+			targetProxy = 5596422E1D2452E300CB6448 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -473,6 +703,94 @@
 			};
 			name = Release;
 		};
+		559641FC1D2451B200CB6448 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Debug;
+		};
+		559641FD1D2451B200CB6448 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Release;
+		};
+		5596420B1D2451BA00CB6448 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Debug;
+		};
+		5596420C1D2451BA00CB6448 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Release;
+		};
+		559642171D2451C100CB6448 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = watchos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+			};
+			name = Debug;
+		};
+		559642181D2451C100CB6448 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccess/Info.plist;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = watchos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+			};
+			name = Release;
+		};
+		559642261D2451C800CB6448 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+			};
+			name = Debug;
+		};
+		559642271D2451C800CB6448 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 148E44E91BF9EDE4004FFEC1 /* Tests.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = KeychainAccessTests/Info.plist;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -517,6 +835,42 @@
 			buildConfigurations = (
 				5506E4961D186E12000F03AF /* Debug */,
 				5506E4971D186E12000F03AF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		559641FB1D2451B200CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccess tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				559641FC1D2451B200CB6448 /* Debug */,
+				559641FD1D2451B200CB6448 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5596420A1D2451BA00CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccessTests tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5596420B1D2451BA00CB6448 /* Debug */,
+				5596420C1D2451BA00CB6448 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		559642161D2451C100CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccess watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				559642171D2451C100CB6448 /* Debug */,
+				559642181D2451C100CB6448 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		559642251D2451C800CB6448 /* Build configuration list for PBXNativeTarget "KeychainAccessTests watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				559642261D2451C800CB6448 /* Debug */,
+				559642271D2451C800CB6448 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess OSX.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess OSX.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "140F195B1A49D79400B0016A"
                BuildableName = "KeychainAccess.framework"
-               BlueprintName = "KeychainAccess"
+               BlueprintName = "KeychainAccess OSX"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,8 +29,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "140F19661A49D79500B0016A"
-               BuildableName = "KeychainAccessTests.xctest"
-               BlueprintName = "KeychainAccessTests"
+               BuildableName = "KeychainAccessTests OSX.xctest"
+               BlueprintName = "KeychainAccessTests OSX"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +47,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "140F19661A49D79500B0016A"
-               BuildableName = "KeychainAccessTests.xctest"
-               BlueprintName = "KeychainAccessTests"
+               BuildableName = "KeychainAccessTests OSX.xctest"
+               BlueprintName = "KeychainAccessTests OSX"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +58,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "140F195B1A49D79400B0016A"
             BuildableName = "KeychainAccess.framework"
-            BlueprintName = "KeychainAccess"
+            BlueprintName = "KeychainAccess OSX"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +80,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "140F195B1A49D79400B0016A"
             BuildableName = "KeychainAccess.framework"
-            BlueprintName = "KeychainAccess"
+            BlueprintName = "KeychainAccess OSX"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +98,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "140F195B1A49D79400B0016A"
             BuildableName = "KeychainAccess.framework"
-            BlueprintName = "KeychainAccess"
+            BlueprintName = "KeychainAccess OSX"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess iOS.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess iOS.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+               BuildableName = "KeychainAccess.framework"
+               BlueprintName = "KeychainAccess iOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5506E48B1D186E12000F03AF"
+               BuildableName = "KeychainAccessTests iOS.xctest"
+               BlueprintName = "KeychainAccessTests iOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5506E48B1D186E12000F03AF"
+               BuildableName = "KeychainAccessTests iOS.xctest"
+               BlueprintName = "KeychainAccessTests iOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+            BuildableName = "KeychainAccess.framework"
+            BlueprintName = "KeychainAccess iOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+            BuildableName = "KeychainAccess.framework"
+            BlueprintName = "KeychainAccess iOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5506E47F1D186DA6000F03AF"
+            BuildableName = "KeychainAccess.framework"
+            BlueprintName = "KeychainAccess iOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess tvOS.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess tvOS.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "559641F41D2451B200CB6448"
+               BuildableName = "KeychainAccess tvOS.framework"
+               BlueprintName = "KeychainAccess tvOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "559642001D2451BA00CB6448"
+               BuildableName = "KeychainAccessTests tvOS.xctest"
+               BlueprintName = "KeychainAccessTests tvOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "559641F41D2451B200CB6448"
+            BuildableName = "KeychainAccess tvOS.framework"
+            BlueprintName = "KeychainAccess tvOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "559641F41D2451B200CB6448"
+            BuildableName = "KeychainAccess tvOS.framework"
+            BlueprintName = "KeychainAccess tvOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "559641F41D2451B200CB6448"
+            BuildableName = "KeychainAccess tvOS.framework"
+            BlueprintName = "KeychainAccess tvOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess tvOS.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "559641F41D2451B200CB6448"
-               BuildableName = "KeychainAccess tvOS.framework"
+               BuildableName = "KeychainAccess.framework"
                BlueprintName = "KeychainAccess tvOS"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
@@ -42,12 +42,22 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "559642001D2451BA00CB6448"
+               BuildableName = "KeychainAccessTests tvOS.xctest"
+               BlueprintName = "KeychainAccessTests tvOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "559641F41D2451B200CB6448"
-            BuildableName = "KeychainAccess tvOS.framework"
+            BuildableName = "KeychainAccess.framework"
             BlueprintName = "KeychainAccess tvOS"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
@@ -69,7 +79,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "559641F41D2451B200CB6448"
-            BuildableName = "KeychainAccess tvOS.framework"
+            BuildableName = "KeychainAccess.framework"
             BlueprintName = "KeychainAccess tvOS"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
@@ -87,7 +97,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "559641F41D2451B200CB6448"
-            BuildableName = "KeychainAccess tvOS.framework"
+            BuildableName = "KeychainAccess.framework"
             BlueprintName = "KeychainAccess tvOS"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess watchOS.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess watchOS.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5596420F1D2451C100CB6448"
+               BuildableName = "KeychainAccess watchOS.framework"
+               BlueprintName = "KeychainAccess watchOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5596421B1D2451C800CB6448"
+               BuildableName = "KeychainAccessTests watchOS.xctest"
+               BlueprintName = "KeychainAccessTests watchOS"
+               ReferencedContainer = "container:KeychainAccess.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5596420F1D2451C100CB6448"
+            BuildableName = "KeychainAccess watchOS.framework"
+            BlueprintName = "KeychainAccess watchOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5596420F1D2451C100CB6448"
+            BuildableName = "KeychainAccess watchOS.framework"
+            BlueprintName = "KeychainAccess watchOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5596420F1D2451C100CB6448"
+            BuildableName = "KeychainAccess watchOS.framework"
+            BlueprintName = "KeychainAccess watchOS"
+            ReferencedContainer = "container:KeychainAccess.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess watchOS.xcscheme
+++ b/Lib/KeychainAccess.xcodeproj/xcshareddata/xcschemes/KeychainAccess watchOS.xcscheme
@@ -15,22 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5596420F1D2451C100CB6448"
-               BuildableName = "KeychainAccess watchOS.framework"
+               BuildableName = "KeychainAccess.framework"
                BlueprintName = "KeychainAccess watchOS"
-               ReferencedContainer = "container:KeychainAccess.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5596421B1D2451C800CB6448"
-               BuildableName = "KeychainAccessTests watchOS.xctest"
-               BlueprintName = "KeychainAccessTests watchOS"
                ReferencedContainer = "container:KeychainAccess.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,7 +33,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5596420F1D2451C100CB6448"
-            BuildableName = "KeychainAccess watchOS.framework"
+            BuildableName = "KeychainAccess.framework"
             BlueprintName = "KeychainAccess watchOS"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
@@ -69,7 +55,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5596420F1D2451C100CB6448"
-            BuildableName = "KeychainAccess watchOS.framework"
+            BuildableName = "KeychainAccess.framework"
             BlueprintName = "KeychainAccess watchOS"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>
@@ -87,7 +73,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5596420F1D2451C100CB6448"
-            BuildableName = "KeychainAccess watchOS.framework"
+            BuildableName = "KeychainAccess.framework"
             BlueprintName = "KeychainAccess watchOS"
             ReferencedContainer = "container:KeychainAccess.xcodeproj">
          </BuildableReference>

--- a/Lib/Rakefile
+++ b/Lib/Rakefile
@@ -26,6 +26,18 @@ def destinations(platform: 'iphonesimulator')
   end
 end
 
+def schemes(platform)
+  if platform == 'iphonesimulator' || platform == 'iphoneos'
+    'KeychainAccess iOS'
+  elsif platform == 'watchsimulator' || platform == 'watchos'
+    'KeychainAccess watchOS'
+  elsif platform == 'appletvsimulator' || platform == 'appletvos'
+    'KeychainAccess tvOS'
+  else
+    'KeychainAccess OSX'
+  end
+end
+
 def supportedPlatforms
   ['macosx', 'iphoneos', 'iphonesimulator', 'watchos', 'watchsimulator', 'appletvos', 'appletvsimulator']
 end
@@ -46,7 +58,7 @@ namespace :build do
   supportedPlatforms.product(configurations).each do |platform, configuration|
     XCJobs::Build.new("#{platform}:#{configuration.downcase}") do |t|
       t.project = 'KeychainAccess'
-      t.scheme = 'KeychainAccess'
+      t.scheme = schemes(platform)
       t.sdk = platform
       if platform == 'iphonesimulator'
         t.add_destination('name=iPhone 6,OS=9.1')
@@ -81,7 +93,7 @@ namespace :test do
   supportedPlatforms.product(configurations).each do |platform, configuration|
     XCJobs::Test.new("#{platform}:#{configuration.downcase}") do |t|
       t.project = 'KeychainAccess'
-      t.scheme = 'KeychainAccess'
+      t.scheme = schemes(platform)
       t.sdk = platform
       destinations(platform: platform).each do |destination|
         t.add_destination(destination)


### PR DESCRIPTION
Sorry I wasn't able to update it before the pull request got closed, but this covers the iOS concern of #208, and still keeps all possible targets.