### PR TITLE
Fix get query on OS X

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -568,6 +568,7 @@ public class Keychain {
             query[UseNoAuthenticationUI] = true
         }
         #elseif os(OSX)
+        query[ReturnData] = true
         if #available(OSX 10.11, *) {
             query[UseAuthenticationUI] = UseAuthenticationUIFail
         }


### PR DESCRIPTION
It fixes not to update existing value in specific case