### PR TITLE
RawRepresentable redundant Xcode 8.3 beta

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -2051,7 +2051,7 @@ public enum Status: OSStatus, Error {
     case unexpectedError                    = -99999
 }
 
-extension Status: RawRepresentable, CustomStringConvertible {
+extension Status: CustomStringConvertible {
 
     public init(status: OSStatus) {
         if let mappedStatus = Status(rawValue: status) {


### PR DESCRIPTION
Heya!

## Description
The `Status` enum is explicitly conforming to `RawRepresentable` protocol, which is fine for prior Xcode versions of 8.3 beta.
<img width="752" alt="screen shot 2017-01-25 at 01 57 08" src="https://cloud.githubusercontent.com/assets/6344795/22275014/9c78223e-e2a1-11e6-9091-5bc909f12dbd.png">
In earlier versions this triggers a compiler error.

## Solution
This PR fixes this by removing the explicit declaration of `RawRepresentable` since `Status` already conforms to `OSStatus (Int32)` and `Error` in which each conform to `RawRepresentable`

- [x] All tests **green**

Thanks for KeychainAccess! It's awesome! 👍🏻
Francisco