### PR TITLE
Fix conformance error during compilation in iOS 10.3

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -2051,7 +2051,7 @@ public enum Status: OSStatus, Error {
     case unexpectedError                    = -99999
 }
 
-extension Status: RawRepresentable, CustomStringConvertible {
+extension Status: CustomStringConvertible {
 
     public init(status: OSStatus) {
         if let mappedStatus = Status(rawValue: status) {


### PR DESCRIPTION
Fixed this by removing RawRepresentable from Status class in
Keychain.swift to be able to compile against iOS 10.3.

Tested this against Xcode Version 8.3 beta (8W109m).