### PR TITLE
Fix allKeys() crashes (#284)

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -759,7 +759,7 @@ public final class Keychain {
     }
 
     public func allKeys() -> [String] {
-        return type(of: self).prettify(itemClass: itemClass, items: items()).map { $0["key"] as! String }
+        return type(of: self).prettify(itemClass: itemClass, items: items()).flatMap { $0["key"] as? String }
     }
 
     public class func allItems(_ itemClass: ItemClass) -> [[String: Any]] {


### PR DESCRIPTION
A fix I suggested a couple of months back for #284 and also for the new #302 