### PR TITLE
Revert #303: Restore RawRepresentable conformance

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -2051,7 +2051,7 @@ public enum Status: OSStatus, Error {
     case unexpectedError                    = -99999
 }
 
-extension Status: CustomStringConvertible {
+extension Status: RawRepresentable, CustomStringConvertible {
 
     public init(status: OSStatus) {
         if let mappedStatus = Status(rawValue: status) {


### PR DESCRIPTION
Revert https://github.com/kishikawakatsumi/KeychainAccess/pull/303

Because no longer happen compilation error in Xcode 8.3.