### PR TITLE
fix value conversion error

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -1669,7 +1669,7 @@ extension CFError {
         let code = CFErrorGetCode(self)
         let userInfo = CFErrorCopyUserInfo(self) as! [String: Any]
 
-        return NSError(domain: domain, code: code, userInfo: userInfo)
+        return NSError(domain: domain, code: code, userInfo: userInfo as? [String : Any])
     }
 }
 


### PR DESCRIPTION
Message of error in Xcode 9: `Cannot convert value of type '[NSObject : Any]' to expected argument type '[String : Any]?'`