### PR TITLE
Allow checking for existence without showing Biometry UI

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -744,15 +744,13 @@ public final class Keychain {
     public func contains(_ key: String) throws -> Bool {
         var query = options.query()
         query[AttributeAccount] = key
-        if #available(iOSApplicationExtension 9.0, *) {
+        if #available(iOS 9.0, OSX 10.11, *) {
             query[UseAuthenticationUI] = UseAuthenticationUIFail
         }
         
         let status = SecItemCopyMatching(query as CFDictionary, nil)
         switch status {
-        case errSecSuccess:
-            return true
-        case errSecInteractionNotAllowed:
+        case errSecSuccess, errSecInteractionNotAllowed:
             return true
         case errSecItemNotFound:
             return false

--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -744,10 +744,15 @@ public final class Keychain {
     public func contains(_ key: String) throws -> Bool {
         var query = options.query()
         query[AttributeAccount] = key
-
+        if #available(iOSApplicationExtension 9.0, *) {
+            query[UseAuthenticationUI] = UseAuthenticationUIFail
+        }
+        
         let status = SecItemCopyMatching(query as CFDictionary, nil)
         switch status {
         case errSecSuccess:
+            return true
+        case errSecInteractionNotAllowed:
             return true
         case errSecItemNotFound:
             return false


### PR DESCRIPTION
We can check if biometry protected items exist without prompting for authentication by disabling Authentication UI and checking for `errSecInteractionNotAllowed`