### PR TITLE
Fixed PackageDescription deprecation warnings.

### DIFF
--- a/KeychainAccess.podspec
+++ b/KeychainAccess.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KeychainAccess'
-  s.version          = '3.1.2'
+  s.version          = '3.1.3'
   s.summary          = 'KeychainAccess is a simple Swift wrapper for Keychain that works on iOS and OS X.'
   s.description      = <<-DESC
                          KeychainAccess is a simple Swift wrapper for Keychain that works on iOS and OS X.

--- a/Package@swift-3.swift
+++ b/Package@swift-3.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:3.0
+//
+//  Package@swift-3.swift
+//  KeychainAccess
+//
+//  Created by kishikawa katsumi on 2015/12/4.
+//  Copyright (c) 2015 kishikawa katsumi. All rights reserved.
+//
+
+import PackageDescription
+
+let package = Package(name: "KeychainAccess", dependencies : [], exclude: ["Tests"])

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,6 +1,6 @@
 // swift-tools-version:4.2
 //
-//  Package.swift
+//  Package@swift-4.2.swift
 //  KeychainAccess
 //
 //  Created by kishikawa katsumi on 2015/12/4.
@@ -21,5 +21,5 @@ let package = Package(
             name: "KeychainAccess",
             path: "Sources")
     ],
-    swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
+    swiftLanguageVersions: [.v3, .v4, .v4_2]
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,6 +1,6 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 //
-//  Package.swift
+//  Package@swift-4.swift
 //  KeychainAccess
 //
 //  Created by kishikawa katsumi on 2015/12/4.
@@ -21,5 +21,5 @@ let package = Package(
             name: "KeychainAccess",
             path: "Sources")
     ],
-    swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
+    swiftLanguageVersions: [3, 4]
 )


### PR DESCRIPTION
Using `KeychainAccess` with the [Swift Package Manager](https://github.com/apple/swift-package-manager) will throw deprecations warnings. This is triggered by `KeychainAccess`'s use of the `v3` package description API, which is deprecated.

```
warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): KeychainAccess
```

This pull request [handles Swift versions](https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#handling-version-specific-logic) by using Version-specific tags in the `Package` names.

Additionally the version is bumped to 3.1.3.

### Usage:

```
.package(url: "https://github.com/4np/KeychainAccess.git", from: "3.1.3")
```