### PR TITLE
Update swift-tools-version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
-//
+// swift-tools-version:4.0
+
 //  Package.swift
 //  KeychainAccess
 //
@@ -9,5 +10,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "KeychainAccess"
+    name: "KeychainAccess",
+    products: [
+        .library(name: "KeychainAccess", targets: ["KeychainAccess"])
+    ],
+    targets: [
+        .target(name: "KeychainAccess", path: "Lib/KeychainAccess")
+    ]
 )


### PR DESCRIPTION
Manifest format 3 has been made unavailable in Xcode 10.2 onwards.

The v4 manifest is the next step up and works back to Xcode 9.0.