### PR TITLE
Use same kSecAttrSynchronizable attribute for both reading & writing

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -1201,7 +1201,7 @@ extension Options {
         var query = [String: Any]()
 
         query[Class] = itemClass.rawValue
-        query[AttributeSynchronizable] = SynchronizableAny
+        query[AttributeSynchronizable] = attributes[AttributeSynchronizable] ?? SynchronizableAny
 
         switch itemClass {
         case .genericPassword:


### PR DESCRIPTION
**What's the motivation?**

At the moment all `get` methods have the default query attribute `kSecAttrSynchronizable` set as `kSecAttrSynchronizableAny`. There is no way to request an item with the `false` value for this attribute which should be possible according to the documentation:

> The corresponding value is of type CFString and indicates whether the item in question is synchronized to other devices through iCloud. To add a new synchronizable item, or **to obtain synchronizable results from a query, supply this key with a value of kCFBooleanTrue. If the key is not supplied, or has a value of kCFBooleanFalse, then no synchronizable items are added or returned**. 


**Use case**

In a broader context I have an app which I've recently switched to use **KeychainAccess** replacing another keychain wrapper library, and when submitted to Apple for review I was rejected a couple of times because the app was crashing for the reviewer on startup as it was killed by `watchdog daemon`.

The app itself had a **"fix task"** running on app startup which was updating the access policy for all the keychain items. So the app was basically stuck making queries to keychain according to the stack-trace provided by Apple reviewers and eventually killed by `watchdog daemon`.

I found that the only difference in the query to `SecItemCopyMatching` method between the old library and **KeychainAccess** was that later one was setting `kSecAttrSynchronizable` key value to `kSecAttrSynchronizableAny`, where the former didn't set this attribute at all.

By removing this default attribute I was able to pass the review and haven't had any issues since then.

My speculative guess is that having `kSecAttrSynchronizable` set to `kSecAttrSynchronizableAny` by default affects the performance of the query.

**Solution**

If `synchronizable` option is set on `Keychain` object when use its value for both read and write operations, otherwise fallback to `kSecAttrSynchronizableAny`.
