### PR TITLE
Add get/set/remove ignoring AttributeSynchronizable APIs (`get(_:, ignoringAttributeSynchronizable:)`).

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -1203,7 +1203,7 @@ extension Options {
         var query = [String: Any]()
 
         query[Class] = itemClass.rawValue
-        query[AttributeSynchronizable] = SynchronizableAny
+        query[AttributeSynchronizable] = attributes[AttributeSynchronizable] ?? SynchronizableAny
         if let accessGroup = self.accessGroup {
             query[AttributeAccessGroup] = accessGroup
         }

--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -512,11 +512,23 @@ public final class Keychain {
     // MARK:
 
     public func get(_ key: String) throws -> String? {
-        return try getString(key)
+        return try getString(key, exactly: false)
+    }
+
+    public func get(exactly key: String) throws -> String? {
+        return try getString(key, exactly: true)
     }
 
     public func getString(_ key: String) throws -> String? {
-        guard let data = try getData(key) else  {
+        return try getString(key, exactly: false)
+    }
+
+    public func getString(exactly key: String) throws -> String? {
+        return try getString(key, exactly: true)
+    }
+
+    private func getString(_ key: String, exactly: Bool = false) throws -> String? {
+        guard let data = try getData(key, exactly: exactly) else  {
             return nil
         }
         guard let string = String(data: data, encoding: .utf8) else {
@@ -527,7 +539,15 @@ public final class Keychain {
     }
 
     public func getData(_ key: String) throws -> Data? {
-        var query = options.query()
+        return try getData(key, exactly: false)
+    }
+
+    public func getData(exactly key: String) throws -> Data? {
+        return try getData(key, exactly: true)
+    }
+
+    private func getData(_ key: String, exactly: Bool = false) throws -> Data? {
+        var query = options.query(exactly: exactly)
 
         query[MatchLimit] = MatchLimitOne
         query[ReturnData] = kCFBooleanTrue
@@ -1199,13 +1219,17 @@ extension Keychain: CustomStringConvertible, CustomDebugStringConvertible {
 
 extension Options {
 
-    func query() -> [String: Any] {
+    func query(exactly: Bool = false) -> [String: Any] {
         var query = [String: Any]()
 
         query[Class] = itemClass.rawValue
-        query[AttributeSynchronizable] = attributes[AttributeSynchronizable] ?? SynchronizableAny
         if let accessGroup = self.accessGroup {
             query[AttributeAccessGroup] = accessGroup
+        }
+        if exactly {
+            query[AttributeSynchronizable] = attributes[AttributeSynchronizable] ?? SynchronizableAny
+        } else {
+            query[AttributeSynchronizable] = SynchronizableAny
         }
 
         switch itemClass {

--- a/Lib/KeychainAccessTests/KeychainAccessTests.swift
+++ b/Lib/KeychainAccessTests/KeychainAccessTests.swift
@@ -1618,4 +1618,87 @@ class KeychainAccessTests: XCTestCase {
         }
         #endif
     }
+
+    func testIgnoringAttributeSynchronizable() {
+        let keychain = Keychain(service: "Twitter").synchronizable(false)
+        let keychainSynchronizable = Keychain(service: "Twitter").synchronizable(true)
+
+        XCTAssertNil(try! keychain.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        XCTAssertNil(try! keychain.get("password", ignoringAttributeSynchronizable: false), "not stored password")
+        XCTAssertNil(try! keychainSynchronizable.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        XCTAssertNil(try! keychainSynchronizable.get("password", ignoringAttributeSynchronizable: false), "not stored password")
+
+        do { try keychain.set("kishikawakatsumi", key: "username", ignoringAttributeSynchronizable: false) } catch {}
+        do { try keychainSynchronizable.set("kishikawakatsumi_synchronizable", key: "username", ignoringAttributeSynchronizable: false) } catch {}
+        XCTAssertEqual(try! keychain.get("username", ignoringAttributeSynchronizable: false), "kishikawakatsumi", "stored username")
+        XCTAssertEqual(try! keychainSynchronizable.get("username", ignoringAttributeSynchronizable: false), "kishikawakatsumi_synchronizable", "stored username")
+        XCTAssertNil(try! keychain.get("password", ignoringAttributeSynchronizable: false), "not stored password")
+        XCTAssertNil(try! keychainSynchronizable.get("password", ignoringAttributeSynchronizable: false), "not stored password")
+
+        do { try keychain.set("password1234", key: "password", ignoringAttributeSynchronizable: false) } catch {}
+        do { try keychainSynchronizable.set("password1234_synchronizable", key: "password", ignoringAttributeSynchronizable: false) } catch {}
+        XCTAssertEqual(try! keychain.get("username", ignoringAttributeSynchronizable: false), "kishikawakatsumi", "stored username")
+        XCTAssertEqual(try! keychainSynchronizable.get("username", ignoringAttributeSynchronizable: false), "kishikawakatsumi_synchronizable", "stored username")
+        XCTAssertEqual(try! keychain.get("password", ignoringAttributeSynchronizable: false), "password1234", "stored password")
+        XCTAssertEqual(try! keychainSynchronizable.get("password", ignoringAttributeSynchronizable: false), "password1234_synchronizable", "stored password")
+
+        do { try keychain.remove("username", ignoringAttributeSynchronizable: false) } catch {}
+        XCTAssertNil(try! keychain.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        XCTAssertEqual(try! keychainSynchronizable.get("username", ignoringAttributeSynchronizable: false), "kishikawakatsumi_synchronizable", "stored username")
+
+        do { try keychainSynchronizable.remove("username", ignoringAttributeSynchronizable: false) } catch {}
+        XCTAssertNil(try! keychain.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        XCTAssertNil(try! keychainSynchronizable.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        
+        XCTAssertEqual(try! keychain.get("password", ignoringAttributeSynchronizable: false), "password1234", "stored password")
+        XCTAssertEqual(try! keychainSynchronizable.get("password", ignoringAttributeSynchronizable: false), "password1234_synchronizable", "stored password")
+
+        do { try keychain.removeAll() } catch {}
+        XCTAssertNil(try! keychain.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        XCTAssertNil(try! keychainSynchronizable.get("username", ignoringAttributeSynchronizable: false), "not stored username")
+        XCTAssertNil(try! keychain.get("password", ignoringAttributeSynchronizable: false), "not stored password")
+        XCTAssertNil(try! keychainSynchronizable.get("password", ignoringAttributeSynchronizable: false), "not stored password")
+    }
+
+    func testIgnoringAttributeSynchronizableBackwardCompatibility() {
+        let keychain = Keychain(service: "Twitter").synchronizable(false)
+        let keychainSynchronizable = Keychain(service: "Twitter").synchronizable(true)
+
+        XCTAssertNil(try! keychain.get("username"), "not stored username")
+        XCTAssertNil(try! keychain.get("password"), "not stored password")
+        XCTAssertNil(try! keychainSynchronizable.get("username"), "not stored username")
+        XCTAssertNil(try! keychainSynchronizable.get("password"), "not stored password")
+
+        do { try keychain.set("kishikawakatsumi", key: "username") } catch {}
+        XCTAssertEqual(try! keychain.get("username"), "kishikawakatsumi", "stored username")
+        XCTAssertEqual(try! keychainSynchronizable.get("username"), "kishikawakatsumi", "stored username")
+
+        do { try keychainSynchronizable.set("kishikawakatsumi_synchronizable", key: "username") } catch {}
+        XCTAssertEqual(try! keychain.get("username"), "kishikawakatsumi_synchronizable", "stored username")
+        XCTAssertEqual(try! keychainSynchronizable.get("username"), "kishikawakatsumi_synchronizable", "stored username")
+        XCTAssertNil(try! keychain.get("password"), "not stored password")
+        XCTAssertNil(try! keychainSynchronizable.get("password"), "not stored password")
+
+        do { try keychain.set("password1234", key: "password") } catch {}
+        XCTAssertEqual(try! keychain.get("password"), "password1234", "stored password")
+        XCTAssertEqual(try! keychainSynchronizable.get("password"), "password1234", "stored password")
+
+        do { try keychainSynchronizable.set("password1234_synchronizable", key: "password") } catch {}
+        XCTAssertEqual(try! keychain.get("username"), "kishikawakatsumi_synchronizable", "stored username")
+        XCTAssertEqual(try! keychainSynchronizable.get("username"), "kishikawakatsumi_synchronizable", "stored username")
+        XCTAssertEqual(try! keychain.get("password"), "password1234_synchronizable", "stored password")
+        XCTAssertEqual(try! keychainSynchronizable.get("password"), "password1234_synchronizable", "stored password")
+
+        do { try keychain.remove("username") } catch {}
+        XCTAssertNil(try! keychain.get("username"), "not stored username")
+        XCTAssertNil(try! keychainSynchronizable.get("username"), "not stored username")
+        XCTAssertEqual(try! keychain.get("password"), "password1234_synchronizable", "stored password")
+        XCTAssertEqual(try! keychainSynchronizable.get("password"), "password1234_synchronizable", "stored password")
+
+        do { try keychain.removeAll() } catch {}
+        XCTAssertNil(try! keychain.get("username"), "not stored username")
+        XCTAssertNil(try! keychainSynchronizable.get("username"), "not stored username")
+        XCTAssertNil(try! keychain.get("password"), "not stored password")
+        XCTAssertNil(try! keychainSynchronizable.get("password"), "not stored password")
+    }
 }


### PR DESCRIPTION
Supersedes https://github.com/kishikawakatsumi/KeychainAccess/pull/421

It respects kSecAttrSynchronizable value for a query if set.

Existing APIs:

```swift
get(_:)
getString(_:)
getData(_:)

```

Added APIs:

```swift
get(_:, ignoringAttributeSynchronizable:)
getString(_:, ignoringAttributeSynchronizable:)
getData(_:, ignoringAttributeSynchronizable:)
```

set and remove as same.