### PR TITLE
Prevent showing authentication dialog while checking the existence of the element using contains(key:)

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -745,6 +745,12 @@ public final class Keychain {
         var query = options.query()
         query[AttributeAccount] = key
 
+        if #available(iOS 9.0, *) {
+            query[UseAuthenticationUI] = UseAuthenticationUIFail
+        } else {
+            query[UseNoAuthenticationUI] = kCFBooleanTrue
+        }
+        
         let status = SecItemCopyMatching(query as CFDictionary, nil)
         switch status {
         case errSecSuccess:


### PR DESCRIPTION
Hi!

When the `AuthenticationPolicy` of the keychain element is set, we still are able to check the existence of this element without authentication dialog.

Proposed solution throws `interactionNotAllowed` exception for this kind of elements, so additional function, like this might be helpful:

```swift
func isExists() -> Bool {
    do {
        if try Keychain(service: "someService").contains("someKey") {
            return true
        }
    } catch let error {
        if let error = error as? KeychainAccess.Status, error == .interactionNotAllowed {
            return true
        }
    }
    return false
}
```

We could also put this inside `contains(key:)` method.

Could someone please take a look at this?