### PR TITLE
fix carthage build on xcode11 beta4

### DIFF
--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
 			buildSettings = {
+				LIBRARY_SEARCH_PATHS = "${TOOLCHAIN_DIR}/usr/lib/swift-${SWIFT_VERSION}/${PLATFORM_NAME}";
 			};
 			name = Debug;
 		};
@@ -414,6 +415,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 148E44EB1BF9EEB3004FFEC1 /* KeychainAccess.xcconfig */;
 			buildSettings = {
+				LIBRARY_SEARCH_PATHS = "${TOOLCHAIN_DIR}/usr/lib/swift-${SWIFT_VERSION}/${PLATFORM_NAME}";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
refs: https://github.com/kishikawakatsumi/KeychainAccess/issues/430

Toolchain directory structure is changed. 
Therefore, some library is not found such as swiftCore and carthage build fails.

### in Xocde10.x

```
$ ls /Applications/Xcode10.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos/
arm64			    libswiftAccelerate.dylib	 libswiftCoreAudio.dylib       libswiftCoreMedia.dylib	  libswiftHomeKit.dylib      libswiftModelIO.dylib	    libswiftRemoteMirror.dylib	     libswiftWatchKit.dylib
arm64e			    libswiftAssetsLibrary.dylib  libswiftCoreData.dylib        libswiftDarwin.dylib	  libswiftIntents.dylib      libswiftNaturalLanguage.dylib  libswiftSceneKit.dylib	     libswiftXCTest.dylib
armv7			    libswiftCallKit.dylib	 libswiftCoreFoundation.dylib  libswiftDispatch.dylib	  libswiftMapKit.dylib	     libswiftNetwork.dylib	    libswiftSpriteKit.dylib	     libswiftos.dylib
armv7s			    libswiftCloudKit.dylib	 libswiftCoreGraphics.dylib    libswiftFoundation.dylib   libswiftMediaPlayer.dylib  libswiftObjectiveC.dylib	    libswiftSwiftOnoneSupport.dylib  libswiftsimd.dylib
libswiftARKit.dylib	    libswiftContacts.dylib	 libswiftCoreImage.dylib       libswiftGLKit.dylib	  libswiftMetal.dylib	     libswiftPhotos.dylib	    libswiftUIKit.dylib
libswiftAVFoundation.dylib  libswiftCore.dylib		 libswiftCoreLocation.dylib    libswiftGameplayKit.dylib  libswiftMetalKit.dylib     libswiftQuartzCore.dylib	    libswiftVision.dylib
```

### in Xcode11 beta 

```
# same as Xocde10.x
$ ls /Applications/Xcode11-beta4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos/
layouts-arm64.yaml  layouts-arm64e.yaml  layouts-armv7.yaml  layouts-armv7s.yaml  prebuilt-modules

# with swift version
$ ls /Applications/Xcode11-beta4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/iphoneos/
libswiftARKit.dylib	     libswiftContacts.dylib	   libswiftCoreImage.dylib     libswiftGLKit.dylib	  libswiftMetal.dylib		 libswiftPhotos.dylib		  libswiftVision.dylib
libswiftAVFoundation.dylib   libswiftCore.dylib		   libswiftCoreLocation.dylib  libswiftGameplayKit.dylib  libswiftMetalKit.dylib	 libswiftQuartzCore.dylib	  libswiftWatchKit.dylib
libswiftAccelerate.dylib     libswiftCoreAudio.dylib	   libswiftCoreMedia.dylib     libswiftHomeKit.dylib	  libswiftModelIO.dylib		 libswiftSceneKit.dylib		  libswiftXCTest.dylib
libswiftAssetsLibrary.dylib  libswiftCoreData.dylib	   libswiftDarwin.dylib        libswiftIntents.dylib	  libswiftNaturalLanguage.dylib  libswiftSpriteKit.dylib	  libswiftos.dylib
libswiftCallKit.dylib	     libswiftCoreFoundation.dylib  libswiftDispatch.dylib      libswiftMapKit.dylib	  libswiftNetwork.dylib		 libswiftSwiftOnoneSupport.dylib  libswiftsimd.dylib
libswiftCloudKit.dylib	     libswiftCoreGraphics.dylib    libswiftFoundation.dylib    libswiftMediaPlayer.dylib  libswiftObjectiveC.dylib	 libswiftUIKit.dylib
```

so I add a path to `library search path`