### PR TITLE
fix: Remove default service property set

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -459,9 +459,6 @@ public final class Keychain {
 
     public convenience init(accessGroup: String) {
         var options = Options()
-        if let bundleIdentifier = Bundle.main.bundleIdentifier {
-            options.service = bundleIdentifier
-        }
         options.accessGroup = accessGroup
         self.init(options)
     }


### PR DESCRIPTION
After set param 'kSecAttrService' in query, accessGroup become inaccessible. Removing param 'kSecAttrService' from initializer with accessGroup make it work