### PR TITLE
Set swift package manager library type to dynamic.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
-        .library(name: "KeychainAccess", targets: ["KeychainAccess"])
+        .library(name: "KeychainAccess", type: .dynamic, targets: ["KeychainAccess"])
     ],
     targets: [
         .target(name: "KeychainAccess", path: "Lib/KeychainAccess")


### PR DESCRIPTION
Addresses issue #472 