### PR TITLE
Update deployment target to iOS 9 for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 let package = Package(
     name: "KeychainAccess",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "KeychainAccess", targets: ["KeychainAccess"])


### PR DESCRIPTION
With Xcode 12, iOS 8 is no longer supported as a deployment target, and it throws a warning if the package tries to support 8.