### PR TITLE
Added `containsAny`method

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -835,9 +835,9 @@ public final class Keychain {
 
     // MARK:
 
-    public func contains(_ key: String, withoutAuthenticationUI: Bool = false) throws -> Bool {
+    private func contains(query queryAttributes: [String:Any], withoutAuthenticationUI: Bool = false) throws -> Bool {
         var query = options.query()
-        query[AttributeAccount] = key
+        queryAttributes.forEach { query.updateValue($1, forKey: $0) }
 
         if withoutAuthenticationUI {
             #if os(iOS) || os(watchOS) || os(tvOS)
@@ -884,7 +884,15 @@ public final class Keychain {
             throw securityError(status: status)
         }
     }
-
+    
+    public func contains(_ key: String, withoutAuthenticationUI: Bool = false) throws -> Bool {
+        return try self.contains(query:[AttributeAccount:key])
+    }
+    
+    public func containsAny(withoutAuthenticationUI: Bool = false) throws -> Bool {
+        return try self.contains(query:[:])
+    }
+    
     // MARK:
 
     public class func allKeys(_ itemClass: ItemClass) -> [(String, String)] {

--- a/Lib/KeychainAccessTests/KeychainAccessTests.swift
+++ b/Lib/KeychainAccessTests/KeychainAccessTests.swift
@@ -542,6 +542,15 @@ class KeychainAccessTests: XCTestCase {
         XCTAssertTrue(try! keychain.contains("username"), "stored username")
         XCTAssertTrue(try! keychain.contains("password"), "stored password")
     }
+    
+    func testContainsAny() {
+        let keychain = Keychain(service: "Twitter")
+
+        XCTAssertFalse(try! keychain.containsAny(), "not stored username")
+
+        do { try keychain.set("kishikawakatsumi", key: "username") } catch {}
+        XCTAssertTrue(try! keychain.containsAny(), "stored username")
+    }
 
     // MARK:
 


### PR DESCRIPTION
The `contains` method requires specific key to search. To simply check if any item is present in the keychain, use `containsAny`.

The method is motivated by the following use case:

* I want to store a username-password pair in the keychain using TouchID/FaceID. The UI should present a button to retrieve the credentials from the keychain - but only if it contains at least one element.