### PR TITLE
Fix Xcode 12 warning when depending on Swift package

### DIFF
--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+
+//  Package.swift
+//  KeychainAccess
+//
+//  Created by kishikawa katsumi on 2015/12/4.
+//  Copyright (c) 2015 kishikawa katsumi. All rights reserved.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "KeychainAccess",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
+    ],
+    products: [
+        .library(name: "KeychainAccess", targets: ["KeychainAccess"])
+    ],
+    targets: [
+        .target(name: "KeychainAccess", path: "Lib/KeychainAccess")
+    ]
+)


### PR DESCRIPTION
A copy of Package.swift with `swift-tools-version` updated to 5.3 and iOS platform updated to iOS 9.

Having this as a separate file prevents breaking backwards compatibility with Swift < 5.3 projects that support iOS 8.