### PR TITLE
Removed explicit platforms definition from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,6 @@ import PackageDescription
 
 let package = Package(
     name: "KeychainAccess",
-    platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
-    ],
     products: [
         .library(name: "KeychainAccess", targets: ["KeychainAccess"])
     ],


### PR DESCRIPTION
This resolves `IPHONEOS_DEPLOYMENT_TARGET` warnings in newer Xcode versions. See https://github.com/nanopb/nanopb/pull/585 for reference — I assume the same applies for this project. The toolchain will this way always choose the latest supported platform version.