### PR TITLE
Fix macOS Access Groups

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -893,7 +893,7 @@ public final class Keychain {
         query[AttributeSynchronizable] = SynchronizableAny
         query[MatchLimit] = MatchLimitAll
         query[ReturnAttributes] = kCFBooleanTrue
-
+        
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
@@ -1364,6 +1364,12 @@ extension Options {
             }
         }
         #endif
+        
+        if #available(iOS 13.0, OSX 10.15, watchOS 6.0, tvOS 13.0, *) {
+            if accessGroup != nil {
+                query[UseDataProtectionKeychain] = true
+            }
+        }
 
         return query
     }
@@ -1406,6 +1412,12 @@ extension Options {
         }
 
         attributes[AttributeSynchronizable] = synchronizable ? kCFBooleanTrue : kCFBooleanFalse
+        
+        if #available(iOS 13.0, OSX 10.15, watchOS 6.0, tvOS 13.0, *) {
+            if accessGroup != nil {
+                attributes[UseDataProtectionKeychain] = true
+            }
+        }
 
         return (attributes, nil)
     }

--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -1299,6 +1299,9 @@ private let UseAuthenticationUIFail = String(kSecUseAuthenticationUIFail)
 @available(iOS 9.0, OSX 10.11, watchOS 2.0, tvOS 9.0, *)
 private let UseAuthenticationUISkip = String(kSecUseAuthenticationUISkip)
 
+@available(iOS 13.0, OSX 10.15, watchOS 6.0, tvOS 13.0, *)
+private let UseDataProtectionKeychain = String(kSecUseDataProtectionKeychain)
+
 #if os(iOS) && !targetEnvironment(macCatalyst)
 /** Credential Key Constants */
 private let SharedPassword = String(kSecSharedPassword)

--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -887,13 +887,19 @@ public final class Keychain {
 
     // MARK:
 
-    public class func allKeys(_ itemClass: ItemClass) -> [(String, String)] {
+    public class func allKeys(_ itemClass: ItemClass, accessGroupsCompatible: Bool = true) -> [(String, String)] {
         var query = [String: Any]()
         query[Class] = itemClass.rawValue
         query[AttributeSynchronizable] = SynchronizableAny
         query[MatchLimit] = MatchLimitAll
         query[ReturnAttributes] = kCFBooleanTrue
         
+        if #available(iOS 13.0, OSX 10.15, watchOS 6.0, tvOS 13.0, *) {
+            if accessGroupsCompatible {
+                query[UseDataProtectionKeychain] = true
+            }
+        }
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 


### PR DESCRIPTION
When using Access Groups on macOS `kSecUseDataProtectionKeychain` needs to be set to `true`:

https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain

> Set the value for this key to true in the query dictionary when accessing a macOS keychain item that behaves like an iOS keychain item. For example, use the data protection key when adding, searching for, or deleting an item to which the [kSecAttrAccessible](doc://com.apple.documentation/documentation/security/ksecattraccessible?language=swift) or [kSecAttrAccessGroup](doc://com.apple.documentation/documentation/security/ksecattraccessgroup?language=swift) attributes apply.

> The data protection key affects operations only in macOS. Other platforms automatically behave as if the key is set to true, and ignore the key in the query dictionary. You can safely use the key on all platforms.

> Tip
> It’s highly recommended that you set the value of this key to true for all keychain operations. This key helps to improve the portability of your code across platforms. Use it unless you specifically need access to items previously stored in a legacy keychain in macOS.

This pull request is a first fix for issues #438, #491 and #535