### PR TITLE
update CocoaPods link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Build Status](https://travis-ci.com/kishikawakatsumi/KeychainAccess.svg?branch=master)](https://travis-ci.com/kishikawakatsumi/KeychainAccess)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![SPM supported](https://img.shields.io/badge/SPM-supported-DE5C43.svg?style=flat)](https://swift.org/package-manager)
-[![Version](https://img.shields.io/cocoapods/v/KeychainAccess.svg)](http://cocoadocs.org/docsets/KeychainAccess)
-[![Platform](https://img.shields.io/cocoapods/p/KeychainAccess.svg)](http://cocoadocs.org/docsets/KeychainAccess)
+[![CocoaPods compatible](https://img.shields.io/badge/CocoaPods-compatible-FF0000.svg?style=flat)](https://cocoapods.org/pods/KeychainAccess)
 
 KeychainAccess is a simple Swift wrapper for Keychain that works on iOS and OS X. Makes using Keychain APIs extremely easy and much more palatable to use in Swift.
 


### PR DESCRIPTION
`https://img.shields.io/cocoapods/v/` and `https://img.shields.io/cocoapods/p/` are broken