### PR TITLE
 Fix issue where Screenshot images were appearing in Xcode 

### DIFF
--- a/Screenshots/Package.swift
+++ b/Screenshots/Package.swift
@@ -1,0 +1,5 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package()


### PR DESCRIPTION
Noticed an unexpected issue where screenshot PNG files were being displayed in Xcode's Attribute inspector.

This pull request addresses this issue by introducing an empty package within the Screenshots folder, resolving the problem encountered. For further details on the solution, refer to this Stack Overflow post: [Link to Stack Overflow](https://stackoverflow.com/a/76473144/14513938).

Attempts were made to exclude the Screenshots directory using `.target(excluded: [...])`, but unfortunately, these were not successful.

| Before     | After        |
| ------------- |-------------|
| <img width="1193" alt="Before" src="https://github.com/kishikawakatsumi/KeychainAccess/assets/9528685/28fd790a-8290-4744-9c06-670919456758"> | <img width="1195" alt="Screenshot 2023-10-18 at 9 18 17" src="https://github.com/kishikawakatsumi/KeychainAccess/assets/9528685/369c7805-ebca-49ed-b9b0-51697dc3ee59"> |




