### PR TITLE
Add PrivacyInfo.xcprivacy

### DIFF
--- a/KeychainAccess.podspec
+++ b/KeychainAccess.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.source_files = 'Lib/KeychainAccess/*.swift'
+  s.resources = ['Lib/KeychainAccess/PrivacyInfo.xcprivacy']
 
   s.swift_version = '5.1'
 

--- a/Lib/KeychainAccess.xcodeproj/project.pbxproj
+++ b/Lib/KeychainAccess.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		14A6301F1D3293C700809B3F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14A6301E1D3293C700809B3F /* Assets.xcassets */; };
 		14C3A6781D32BF9C00349459 /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 140F195C1A49D79400B0016A /* KeychainAccess.framework */; };
 		14C3A6791D32BF9C00349459 /* KeychainAccess.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 140F195C1A49D79400B0016A /* KeychainAccess.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AAD69D502B51371200BE0369 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AAD69D4F2B51367600BE0369 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		14A630231D3293C700809B3F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14F0C1961D3295C4007DCDDB /* TestHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TestHost.entitlements; sourceTree = "<group>"; };
 		14F0C1981D329832007DCDDB /* TestHost.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = TestHost.xcconfig; path = Configurations/TestHost.xcconfig; sourceTree = "<group>"; };
+		AAD69D4F2B51367600BE0369 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +144,7 @@
 			isa = PBXGroup;
 			children = (
 				140F19601A49D79400B0016A /* Info.plist */,
+				AAD69D4F2B51367600BE0369 /* PrivacyInfo.xcprivacy */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -320,6 +323,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAD69D502B51371200BE0369 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Lib/KeychainAccess/PrivacyInfo.xcprivacy
+++ b/Lib/KeychainAccess/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   PrivacyInfo.xcprivacy
+   KeychainAccess
+
+   Created by KENJIWADA on 2024/01/12.
+   Copyright (c) 2024 kishikawa katsumi. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Lib/KeychainAccess/PrivacyInfo.xcprivacy
+++ b/Lib/KeychainAccess/PrivacyInfo.xcprivacy
@@ -9,15 +9,6 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>0A2A.1</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/Lib/KeychainAccess/PrivacyInfo.xcprivacy
+++ b/Lib/KeychainAccess/PrivacyInfo.xcprivacy
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   PrivacyInfo.xcprivacy
-   KeychainAccess
-
-   Created by KENJIWADA on 2024/01/12.
-   Copyright (c) 2024 kishikawa katsumi. All rights reserved.
--->
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
         .target(
           name: "KeychainAccess",
           path: "Lib/KeychainAccess",
+          exclude: ["PrivacyInfo.xcprivacy"],
           linkerSettings: [.unsafeFlags(["-Xlinker", "-no_application_extension"])])
     ]
 )

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -21,7 +21,7 @@ let package = Package(
         .target(
           name: "KeychainAccess",
           path: "Lib/KeychainAccess",
-          exclude: ["Info.plist"],
+          exclude: ["Info.plist", "PrivacyInfo.xcprivacy"],
           linkerSettings: [.unsafeFlags(["-Xlinker", "-no_application_extension"])]
         )
     ]


### PR DESCRIPTION
ref: #587 #589

File timestamp APIs were not used in this library. Therefore, I added an empty PrivacyInfo.xcprivacy.

このライブラリでは File timestamp APIs が使われていないため、空のPrivacyInfo.xcprivacyを追加しました。

~~As pointed out in #589, we are using File timestamp APIs, so I think we need to comply with Privacy Manifests. I have added PrivacyInfo.xcprivacy, but I was unsure whether it is appropriate to set `NSPrivacyAccessedAPITypeReasons` to `0A2A.1`.~~

~~#589 での指摘通り、File timestamp APIs を使っているので、Privacy Manifests対応が必要かと思います。　PrivacyInfo.xcprivacy の追加はできましたが、`NSPrivacyAccessedAPITypeReasons` を `0A2A.1` にするのが適切かどうか判断できませんでした。~~