### PR TITLE
Remove deprecated kSecAttrAccessible values

### DIFF
--- a/Lib/KeychainAccess/Keychain.swift
+++ b/Lib/KeychainAccess/Keychain.swift
@@ -101,15 +101,6 @@ public enum Accessibility {
     case afterFirstUnlock
 
     /**
-     Item data can always be accessed
-     regardless of the lock state of the device. This is not recommended
-     for anything except system use. Items with this attribute will migrate
-     to a new device when using encrypted backups.
-     */
-    @available(macCatalyst, unavailable)
-    case always
-
-    /**
      Item data can
      only be accessed while the device is unlocked. This class is only
      available if a passcode is set on the device. This is recommended for
@@ -141,16 +132,6 @@ public enum Accessibility {
      be missing.
      */
     case afterFirstUnlockThisDeviceOnly
-
-    /**
-     Item data can always
-     be accessed regardless of the lock state of the device. This option
-     is not recommended for anything except system use. Items with this
-     attribute will never migrate to a new device, so after a backup is
-     restored to a new device, these items will be missing.
-     */
-    @available(macCatalyst, unavailable)
-    case alwaysThisDeviceOnly
 }
 
 /**
@@ -1725,20 +1706,12 @@ extension Accessibility: RawRepresentable, CustomStringConvertible {
                 self = .whenUnlocked
             case String(kSecAttrAccessibleAfterFirstUnlock):
                 self = .afterFirstUnlock
-            #if !targetEnvironment(macCatalyst)
-            case String(kSecAttrAccessibleAlways):
-                self = .always
-            #endif
             case String(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly):
                 self = .whenPasscodeSetThisDeviceOnly
             case String(kSecAttrAccessibleWhenUnlockedThisDeviceOnly):
                 self = .whenUnlockedThisDeviceOnly
             case String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly):
                 self = .afterFirstUnlockThisDeviceOnly
-            #if !targetEnvironment(macCatalyst)
-            case String(kSecAttrAccessibleAlwaysThisDeviceOnly):
-                self = .alwaysThisDeviceOnly
-            #endif
             default:
                 return nil
             }
@@ -1748,18 +1721,10 @@ extension Accessibility: RawRepresentable, CustomStringConvertible {
                 self = .whenUnlocked
             case String(kSecAttrAccessibleAfterFirstUnlock):
                 self = .afterFirstUnlock
-            #if !targetEnvironment(macCatalyst)
-            case String(kSecAttrAccessibleAlways):
-                self = .always
-            #endif
             case String(kSecAttrAccessibleWhenUnlockedThisDeviceOnly):
                 self = .whenUnlockedThisDeviceOnly
             case String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly):
                 self = .afterFirstUnlockThisDeviceOnly
-            #if !targetEnvironment(macCatalyst)
-            case String(kSecAttrAccessibleAlwaysThisDeviceOnly):
-                self = .alwaysThisDeviceOnly
-            #endif
             default:
                 return nil
             }
@@ -1772,10 +1737,6 @@ extension Accessibility: RawRepresentable, CustomStringConvertible {
             return String(kSecAttrAccessibleWhenUnlocked)
         case .afterFirstUnlock:
             return String(kSecAttrAccessibleAfterFirstUnlock)
-        #if !targetEnvironment(macCatalyst)
-        case .always:
-            return String(kSecAttrAccessibleAlways)
-        #endif
         case .whenPasscodeSetThisDeviceOnly:
             if #available(macOS 10.10, *) {
                 return String(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
@@ -1786,10 +1747,6 @@ extension Accessibility: RawRepresentable, CustomStringConvertible {
             return String(kSecAttrAccessibleWhenUnlockedThisDeviceOnly)
         case .afterFirstUnlockThisDeviceOnly:
             return String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
-        #if !targetEnvironment(macCatalyst)
-        case .alwaysThisDeviceOnly:
-            return String(kSecAttrAccessibleAlwaysThisDeviceOnly)
-        #endif
         }
     }
 
@@ -1799,20 +1756,12 @@ extension Accessibility: RawRepresentable, CustomStringConvertible {
             return "WhenUnlocked"
         case .afterFirstUnlock:
             return "AfterFirstUnlock"
-        #if !targetEnvironment(macCatalyst)
-        case .always:
-            return "Always"
-        #endif
         case .whenPasscodeSetThisDeviceOnly:
             return "WhenPasscodeSetThisDeviceOnly"
         case .whenUnlockedThisDeviceOnly:
             return "WhenUnlockedThisDeviceOnly"
         case .afterFirstUnlockThisDeviceOnly:
             return "AfterFirstUnlockThisDeviceOnly"
-        #if !targetEnvironment(macCatalyst)
-        case .alwaysThisDeviceOnly:
-            return "AlwaysThisDeviceOnly"
-        #endif
         }
     }
 }


### PR DESCRIPTION
Apple has deprecated kSecAttrAccessibleAlways and kSecAttrAccessibleAlwaysThisDeviceOnly, as these values no longer align with recommended security practices. 
To ensure the KeychainAccess library remains up-to-date and maintains best security practices, these deprecated values have been removed.

resolves #508 